### PR TITLE
Fix Composer Dependency: EventManager is required for TableGateway

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     },
     "require": {
         "php": ">=5.3.23",
+        "zendframework/zend-eventmanager": "~2.4",
         "zendframework/zend-stdlib": "~2.4"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "~2.4",
         "zendframework/zend-mvc": "~2.4",
         "zendframework/zend-servicemanager": "~2.4",
         "fabpot/php-cs-fixer": "1.7.*",


### PR DESCRIPTION
## Overview

As stated, this currently causes issues with anyone that is using TableGateway as the EventManager is a dependency.

## Workaround

```
composer require zendframework/zend-eventmanager
```

