### PR TITLE
Fixes #14 : Added Sql\Predicate\NotBetween

### DIFF
--- a/src/Sql/Predicate/NotBetween.php
+++ b/src/Sql/Predicate/NotBetween.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Predicate;
+
+class NotBetween extends Between
+{
+    protected $specification = '%1$s NOT BETWEEN %2$s AND %3$s';
+}

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -383,6 +383,27 @@ class Predicate extends PredicateSet
     }
 
     /**
+     * Create "NOT BETWEEN" predicate
+     *
+     * Utilizes NotBetween predicate
+     *
+     * @param  string $identifier
+     * @param  int|float|string $minValue
+     * @param  int|float|string $maxValue
+     * @return Predicate
+     */
+    public function notBetween($identifier, $minValue, $maxValue)
+    {
+        $this->addPredicate(
+            new NotBetween($identifier, $minValue, $maxValue),
+            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+        );
+        $this->nextPredicateCombineOperator = null;
+
+        return $this;
+    }
+
+    /**
      * Use given predicate directly
      *
      * Contrary to {@link addPredicate()} this method respects formerly set

--- a/test/Sql/Predicate/NotBetweenTest.php
+++ b/test/Sql/Predicate/NotBetweenTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Predicate;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Db\Sql\Predicate\NotBetween;
+
+class NotBetweenTest extends TestCase
+{
+    /**
+     * @var NotBetween
+     */
+    protected $notBetween = null;
+
+    public function setUp()
+    {
+        $this->notBetween = new NotBetween();
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Predicate\NotBetween::getSpecification
+     */
+    public function testSpecificationHasSameDefaultValue()
+    {
+        $this->assertEquals('%1$s NOT BETWEEN %2$s AND %3$s', $this->notBetween->getSpecification());
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Predicate\NotBetween::getExpressionData
+     */
+    public function testRetrievingWherePartsReturnsSpecificationArrayOfIdentifierAndValuesAndArrayOfTypes()
+    {
+        $this->notBetween->setIdentifier('foo.bar')
+                      ->setMinValue(10)
+                      ->setMaxValue(19);
+        $expected = [[
+            $this->notBetween->getSpecification(),
+            ['foo.bar', 10, 19],
+            [NotBetween::TYPE_IDENTIFIER, NotBetween::TYPE_VALUE, NotBetween::TYPE_VALUE],
+        ]];
+        $this->assertEquals($expected, $this->notBetween->getExpressionData());
+
+        $this->notBetween->setIdentifier([10=>NotBetween::TYPE_VALUE])
+                      ->setMinValue(['foo.bar'=>NotBetween::TYPE_IDENTIFIER])
+                      ->setMaxValue(['foo.baz'=>NotBetween::TYPE_IDENTIFIER]);
+        $expected = [[
+            $this->notBetween->getSpecification(),
+            [10, 'foo.bar', 'foo.baz'],
+            [NotBetween::TYPE_VALUE, NotBetween::TYPE_IDENTIFIER, NotBetween::TYPE_IDENTIFIER],
+        ]];
+        $this->assertEquals($expected, $this->notBetween->getExpressionData());
+    }
+}

--- a/test/Sql/Predicate/PredicateTest.php
+++ b/test/Sql/Predicate/PredicateTest.php
@@ -157,6 +157,16 @@ class PredicateTest extends TestCase
         $this->assertContains(['foo.bar', 1, 10], $parts[0]);
     }
 
+    public function testBetweenCreatesNotBetweenPredicate()
+    {
+        $predicate = new Predicate();
+        $predicate->notBetween('foo.bar', 1, 10);
+        $parts = $predicate->getExpressionData();
+        $this->assertEquals(1, count($parts));
+        $this->assertContains('%1$s NOT BETWEEN %2$s AND %3$s', $parts[0]);
+        $this->assertContains(['foo.bar', 1, 10], $parts[0]);
+    }
+
     public function testCanChainPredicateFactoriesBetweenOperators()
     {
         $predicate = new Predicate();


### PR DESCRIPTION
Adds a `NotBetween` predicate:

```php
$sql->notBetween('count', 1, 5);
```

Where 'count' is the field identifier, 1 is the minimum (left side), and 5 is the maximum (right side).