### PR TITLE
Allowed HydratingResultSet to accept a PrototypeFactoryInterface

### DIFF
--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\ResultSet;
 
 use ArrayObject;
+use Zend\Db\ResultSet\HydratingResultSet\PrototypeFactoryInterface;
 use Zend\Stdlib\Hydrator\ArraySerializable;
 use Zend\Stdlib\Hydrator\HydratorInterface;
 
@@ -99,8 +100,16 @@ class HydratingResultSet extends AbstractResultSet
         } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
             return $this->buffer[$this->position];
         }
+
         $data = $this->dataSource->current();
-        $object = is_array($data) ? $this->hydrator->hydrate($data, clone $this->objectPrototype) : false;
+
+        if ($this->objectPrototype instanceof PrototypeFactoryInterface) {
+            $prototype = $this->objectPrototype->createPrototype($data);
+        } else {
+            $prototype = clone $this->objectPrototype;
+        }
+
+        $object = is_array($data) ? $this->hydrator->hydrate($data, $prototype) : false;
 
         if (is_array($this->buffer)) {
             $this->buffer[$this->position] = $object;

--- a/src/ResultSet/HydratingResultSet/PrototypeFactoryInterface.php
+++ b/src/ResultSet/HydratingResultSet/PrototypeFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\ResultSet\HydratingResultSet;
+
+/**
+ * Interface PrototypeFactoryInterface
+ * @package Zend\Db\ResultSet\HydratingResultSet
+ */
+interface PrototypeFactoryInterface
+{
+    /**
+     * @param mixed $data
+     * @return object
+     */
+    public function createPrototype($data);
+}

--- a/test/ResultSet/HydratingResultSetIntegrationTest.php
+++ b/test/ResultSet/HydratingResultSetIntegrationTest.php
@@ -29,4 +29,27 @@ class HydratingResultSetIntegrationTest extends \PHPUnit_Framework_TestCase
         $obj2 = $hydratingRs->current();
         $this->assertSame($obj1, $obj2);
     }
+
+    /**
+     * @covers Zend\Db\ResultSet\HydratingResultSet::current
+     */
+    public function testCurrentUsesPrototypeFactory()
+    {
+        $dataSource = new \ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ]);
+
+        $factory = $this->getMock('\Zend\Db\ResultSet\HydratingResultSet\PrototypeFactoryInterface');
+        $factory->expects($this->once())
+            ->method('createPrototype')
+            ->with($dataSource[0])
+            ->will($this->returnValue(new \ArrayObject));
+
+        $hydratingRs = new HydratingResultSet;
+        $hydratingRs->setObjectPrototype($factory);
+        $hydratingRs->initialize($dataSource);
+
+        $this->assertInstanceOf('\ArrayObject', $hydratingRs->current());
+    }
 }


### PR DESCRIPTION
This change allows an instance of a PrototypeFactoryInterface to be used
instead of an object prototype.  The factory will be passed the result
data and must return an object to be hydrated.

This would resolve Issue https://github.com/zendframework/zend-db/issues/18