### PR TITLE
Deprecate Zend\Db\Metadata\Metadata in favor of Zend\Db\Metadata\Source\Factory

### DIFF
--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -32,11 +32,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get base tables and views
-     *
-     * @param string $schema
-     * @param bool   $includeViews
-     * @return Object\TableObject[]
+     * {@inheritdoc}
      */
     public function getTables($schema = null, $includeViews = false)
     {
@@ -44,10 +40,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get base tables and views
-     *
-     * @param string $schema
-     * @return Object\TableObject[]
+     * {@inheritdoc}
      */
     public function getViews($schema = null)
     {
@@ -55,10 +48,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get triggers
-     *
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getTriggers($schema = null)
     {
@@ -66,11 +56,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get constraints
-     *
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getConstraints($table, $schema = null)
     {
@@ -78,11 +64,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get columns
-     *
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getColumns($table, $schema = null)
     {
@@ -90,12 +72,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get constraint keys
-     *
-     * @param  string $constraint
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getConstraintKeys($constraint, $table, $schema = null)
     {
@@ -103,12 +80,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get constraints
-     *
-     * @param  string $constraintName
-     * @param  string $table
-     * @param  string $schema
-     * @return Object\ConstraintObject
+     * {@inheritdoc}
      */
     public function getConstraint($constraintName, $table, $schema = null)
     {
@@ -116,7 +88,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get schemas
+     * {@inheritdoc}
      */
     public function getSchemas()
     {
@@ -124,11 +96,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get table names
-     *
-     * @param  string $schema
-     * @param  bool   $includeViews
-     * @return array
+     * {@inheritdoc}
      */
     public function getTableNames($schema = null, $includeViews = false)
     {
@@ -136,11 +104,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get table
-     *
-     * @param  string $tableName
-     * @param  string $schema
-     * @return Object\TableObject
+     * {@inheritdoc}
      */
     public function getTable($tableName, $schema = null)
     {
@@ -148,10 +112,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get views names
-     *
-     * @param string $schema
-     * @return \Zend\Db\Metadata\Object\TableObject
+     * {@inheritdoc}
      */
     public function getViewNames($schema = null)
     {
@@ -159,11 +120,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get view
-     *
-     * @param string $viewName
-     * @param string $schema
-     * @return \Zend\Db\Metadata\Object\TableObject
+     * {@inheritdoc}
      */
     public function getView($viewName, $schema = null)
     {
@@ -171,10 +128,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get trigger names
-     *
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getTriggerNames($schema = null)
     {
@@ -182,11 +136,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get trigger
-     *
-     * @param string $triggerName
-     * @param string $schema
-     * @return \Zend\Db\Metadata\Object\TriggerObject
+     * {@inheritdoc}
      */
     public function getTrigger($triggerName, $schema = null)
     {
@@ -194,11 +144,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get column names
-     *
-     * @param string $table
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getColumnNames($table, $schema = null)
     {
@@ -206,12 +152,7 @@ class Metadata implements MetadataInterface
     }
 
     /**
-     * Get column
-     *
-     * @param string $columnName
-     * @param string $table
-     * @param string $schema
-     * @return \Zend\Db\Metadata\Object\ColumnObject
+     * {@inheritdoc}
      */
     public function getColumn($columnName, $table, $schema = null)
     {

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -11,6 +11,9 @@ namespace Zend\Db\Metadata;
 
 use Zend\Db\Adapter\Adapter;
 
+/**
+ * @deprecated Use Zend\Db\Metadata\Source\Factory::createSourceFromAdapter($adapter)
+ */
 class Metadata implements MetadataInterface
 {
     /**
@@ -25,34 +28,8 @@ class Metadata implements MetadataInterface
      */
     public function __construct(Adapter $adapter)
     {
-        $this->source = $this->createSourceFromAdapter($adapter);
+        $this->source = Source\Factory::createSourceFromAdapter($adapter);
     }
-
-    /**
-     * Create source from adapter
-     *
-     * @param  Adapter $adapter
-     * @return Source\AbstractSource
-     */
-    protected function createSourceFromAdapter(Adapter $adapter)
-    {
-        switch ($adapter->getPlatform()->getName()) {
-            case 'MySQL':
-                return new Source\MysqlMetadata($adapter);
-            case 'SQLServer':
-                return new Source\SqlServerMetadata($adapter);
-            case 'SQLite':
-                return new Source\SqliteMetadata($adapter);
-            case 'PostgreSQL':
-                return new Source\PostgresqlMetadata($adapter);
-            case 'Oracle':
-                return new Source\OracleMetadata($adapter);
-        }
-
-        throw new \Exception('cannot create source from adapter');
-    }
-
-    // @todo methods
 
     /**
      * Get base tables and views

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -14,13 +14,6 @@ use Zend\Db\Adapter\Adapter;
 class Metadata implements MetadataInterface
 {
     /**
-     * Adapter
-     *
-     * @var Adapter
-     */
-    protected $adapter = null;
-
-    /**
      * @var MetadataInterface
      */
     protected $source = null;
@@ -32,7 +25,6 @@ class Metadata implements MetadataInterface
      */
     public function __construct(Adapter $adapter)
     {
-        $this->adapter = $adapter;
         $this->source = $this->createSourceFromAdapter($adapter);
     }
 

--- a/src/Metadata/MetadataInterface.php
+++ b/src/Metadata/MetadataInterface.php
@@ -11,25 +11,144 @@ namespace Zend\Db\Metadata;
 
 interface MetadataInterface
 {
+    /**
+     * Get schemas.
+     *
+     * @return string[]
+     */
     public function getSchemas();
 
+    /**
+     * Get table names.
+     *
+     * @param null|string $schema
+     * @param bool $includeViews
+     * @return string[]
+     */
     public function getTableNames($schema = null, $includeViews = false);
+
+    /**
+     * Get tables.
+     *
+     * @param null|string $schema
+     * @param bool $includeViews
+     * @return Object\TableObject[]
+     */
     public function getTables($schema = null, $includeViews = false);
+
+    /**
+     * Get table
+     *
+     * @param string $tableName
+     * @param null|string $schema
+     * @return Object\TableObject
+     */
     public function getTable($tableName, $schema = null);
 
+    /**
+     * Get view names
+     *
+     * @param null|string $schema
+     * @return string[]
+     */
     public function getViewNames($schema = null);
+
+    /**
+     * Get views
+     *
+     * @param null|string $schema
+     * @return Object\ViewObject[]
+     */
     public function getViews($schema = null);
+
+    /**
+     * Get view
+     *
+     * @param string $viewName
+     * @param null|string $schema
+     * @return Object\ViewObject
+     */
     public function getView($viewName, $schema = null);
 
+    /**
+     * Get column names
+     *
+     * @param string $table
+     * @param null|string $schema
+     * @return string[]
+     */
     public function getColumnNames($table, $schema = null);
+
+    /**
+     * Get columns
+     *
+     * @param string $table
+     * @param null|string $schema
+     * @return Object\ColumnObject[]
+     */
     public function getColumns($table, $schema = null);
+
+    /**
+     * Get column
+     *
+     * @param string $columnName
+     * @param string $table
+     * @param null|string $schema
+     * @return Object\ColumnObject
+     */
     public function getColumn($columnName, $table, $schema = null);
 
+    /**
+     * Get constraints
+     *
+     * @param string $table
+     * @param null|string $schema
+     * @return Object\ConstraintObject[]
+     */
     public function getConstraints($table, $schema = null);
+
+    /**
+     * Get constraint
+     *
+     * @param string $constraintName
+     * @param string $table
+     * @param null|string $schema
+     * @return Object\ConstraintObject
+     */
     public function getConstraint($constraintName, $table, $schema = null);
+
+    /**
+     * Get constraint keys
+     *
+     * @param string $constraint
+     * @param string $table
+     * @param null|string $schema
+     * @return Object\ConstraintKeyObject[]
+     */
     public function getConstraintKeys($constraint, $table, $schema = null);
 
+    /**
+     * Get trigger names
+     *
+     * @param null|string $schema
+     * @return string[]
+     */
     public function getTriggerNames($schema = null);
+
+    /**
+     * Get triggers
+     *
+     * @param null|string $schema
+     * @return Object\TriggerObject[]
+     */
     public function getTriggers($schema = null);
+
+    /**
+     * Get trigger
+     *
+     * @param string $triggerName
+     * @param null|string $schema
+     * @return Object\TriggerObject
+     */
     public function getTrigger($triggerName, $schema = null);
 }

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -58,11 +58,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get table names
-     *
-     * @param  string $schema
-     * @param  bool   $includeViews
-     * @return string[]
+     * {@inheritdoc}
      */
     public function getTableNames($schema = null, $includeViews = false)
     {
@@ -86,11 +82,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get tables
-     *
-     * @param  string $schema
-     * @param  bool   $includeViews
-     * @return Object\TableObject[]
+     * {@inheritdoc}
      */
     public function getTables($schema = null, $includeViews = false)
     {
@@ -106,11 +98,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get table
-     *
-     * @param  string $tableName
-     * @param  string $schema
-     * @return Object\TableObject
+     * {@inheritdoc}
      */
     public function getTable($tableName, $schema = null)
     {
@@ -144,10 +132,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get view names
-     *
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getViewNames($schema = null)
     {
@@ -167,10 +152,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get views
-     *
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getViews($schema = null)
     {
@@ -186,11 +168,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get view
-     *
-     * @param string $viewName
-     * @param string $schema
-     * @return \Zend\Db\Metadata\Object\TableObject
+     * {@inheritdoc}
      */
     public function getView($viewName, $schema = null)
     {
@@ -208,11 +186,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Gt column names
-     *
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getColumnNames($table, $schema = null)
     {
@@ -230,11 +204,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get columns
-     *
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getColumns($table, $schema = null)
     {
@@ -252,12 +222,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get column
-     *
-     * @param  string $columnName
-     * @param  string $table
-     * @param  string $schema
-     * @return Object\ColumnObject
+     * {@inheritdoc}
      */
     public function getColumn($columnName, $table, $schema = null)
     {
@@ -301,11 +266,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get constraints
-     *
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getConstraints($table, $schema = null)
     {
@@ -324,12 +285,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get constraint
-     *
-     * @param  string $constraintName
-     * @param  string $table
-     * @param  string $schema
-     * @return Object\ConstraintObject
+     * {@inheritdoc}
      */
     public function getConstraint($constraintName, $table, $schema = null)
     {
@@ -366,12 +322,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get constraint keys
-     *
-     * @param  string $constraint
-     * @param  string $table
-     * @param  string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getConstraintKeys($constraint, $table, $schema = null)
     {
@@ -411,10 +362,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get trigger names
-     *
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getTriggerNames($schema = null)
     {
@@ -428,10 +376,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get triggers
-     *
-     * @param string $schema
-     * @return array
+     * {@inheritdoc}
      */
     public function getTriggers($schema = null)
     {
@@ -447,11 +392,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get trigger
-     *
-     * @param string $triggerName
-     * @param string $schema
-     * @return Object\TriggerObject
+     * {@inheritdoc}
      */
     public function getTrigger($triggerName, $schema = null)
     {

--- a/src/Metadata/Source/Factory.php
+++ b/src/Metadata/Source/Factory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Metadata\Source;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Exception\InvalidArgumentException;
+use Zend\Db\Metadata\MetadataInterface;
+
+/**
+ * Source metadata factory.
+ */
+class Factory
+{
+    /**
+     * Create source from adapter
+     *
+     * @param  Adapter $adapter
+     * @return MetadataInterface
+     * @throws InvalidArgumentException If adapter platform name not recognized.
+     */
+    public static function createSourceFromAdapter(Adapter $adapter)
+    {
+        $platformName = $adapter->getPlatform()->getName();
+
+        switch ($platformName) {
+            case 'MySQL':
+                return new MysqlMetadata($adapter);
+            case 'SQLServer':
+                return new SqlServerMetadata($adapter);
+            case 'SQLite':
+                return new SqliteMetadata($adapter);
+            case 'PostgreSQL':
+                return new PostgresqlMetadata($adapter);
+            case 'Oracle':
+                return new OracleMetadata($adapter);
+            default:
+                throw new InvalidArgumentException("Unknown adapter platform '{$platformName}'");
+        }
+    }
+}

--- a/src/TableGateway/Feature/MetadataFeature.php
+++ b/src/TableGateway/Feature/MetadataFeature.php
@@ -9,10 +9,10 @@
 
 namespace Zend\Db\TableGateway\Feature;
 
-use Zend\Db\Metadata\Metadata;
 use Zend\Db\Metadata\MetadataInterface;
 use Zend\Db\TableGateway\Exception;
 use Zend\Db\Metadata\Object\TableObject;
+use Zend\Db\Metadata\Source\Factory as SourceFactory;
 
 class MetadataFeature extends AbstractFeature
 {
@@ -40,7 +40,7 @@ class MetadataFeature extends AbstractFeature
     public function postInitialize()
     {
         if ($this->metadata === null) {
-            $this->metadata = new Metadata($this->tableGateway->adapter);
+            $this->metadata = SourceFactory::createSourceFromAdapter($this->tableGateway->adapter);
         }
 
         // localize variable for brevity

--- a/test/Metadata/Source/FactoryTest.php
+++ b/test/Metadata/Source/FactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Metadata\Source;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Metadata\Source\Factory;
+
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider validAdapterProvider
+     *
+     * @param Adapter $adapter
+     * @param string $expectedReturnClass
+     */
+    public function testCreateSourceFromAdapter(Adapter $adapter, $expectedReturnClass)
+    {
+        $source = Factory::createSourceFromAdapter($adapter);
+
+        $this->assertInstanceOf('Zend\Db\Metadata\MetadataInterface', $source);
+        $this->assertInstanceOf($expectedReturnClass, $source);
+    }
+
+    public function validAdapterProvider()
+    {
+        $createAdapterForPlatform = function ($platformName) {
+            $platform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
+            $platform
+                ->expects($this->any())
+                ->method('getName')
+                ->willReturn($platformName)
+            ;
+
+            $adapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+
+            $adapter
+                ->expects($this->any())
+                ->method('getPlatform')
+                ->willReturn($platform)
+            ;
+
+            return $adapter;
+        };
+
+        return [
+            // Description => [adapter, expected return class]
+            'MySQL' => [$createAdapterForPlatform('MySQL'), 'Zend\Db\Metadata\Source\MysqlMetadata'],
+            'SQLServer' => [$createAdapterForPlatform('SQLServer'), 'Zend\Db\Metadata\Source\SqlServerMetadata'],
+            'SQLite' => [$createAdapterForPlatform('SQLite'), 'Zend\Db\Metadata\Source\SqliteMetadata'],
+            'PostgreSQL' => [$createAdapterForPlatform('PostgreSQL'), 'Zend\Db\Metadata\Source\PostgresqlMetadata'],
+            'Oracle' => [$createAdapterForPlatform('Oracle'), 'Zend\Db\Metadata\Source\OracleMetadata'],
+        ];
+    }
+}


### PR DESCRIPTION
Current `Zend\Db\Metadata\Metadata` it's a shadow factory. 

This PR extracts the factory functionallity and deprecate the class.

Supersede and Close #4