### PR TITLE
add dependency from zendframework\zend-eventmanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "~2.5",
+        "zendframework/zend-eventmanager": "~2.5"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-mvc": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",


### PR DESCRIPTION
i try use zendframework/zend-db with --no-dev option on my production
```bash
$ mkdir 222
$ cd 222
$ composer require zendframework/zend-db
```
i create index.php:
```php
<?php

include "vendor/autoload.php";

$adapter = new Zend\Db\Adapter\Adapter([
    'driver' => 'Pdo_Pgsql',
    'database' => 'socdate',
    'username' => 'socdate',
    'password' => '111',
    'host' => 'localhost',
    'port' => 5432
]);

use Zend\Db\TableGateway\TableGateway;

$projectTable = new TableGateway('sd_roles', $adapter);
$rowset = $projectTable->select(array('status' => 1));
```
and run
```bash
$ php index.php
PHP Fatal error:  Interface 'Zend\EventManager\EventsCapableInterface' not found in /storage/proj/222/vendor/zendframework/zend-db/src/TableGateway/Feature/EventFeature.php on line 24
```

your require section must contain 'zendframework/zend-eventmanager'