### PR TITLE
Fix values for left and right outer join #26

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -41,8 +41,8 @@ class Select extends AbstractPreparableSql
     const JOIN_OUTER = 'outer';
     const JOIN_LEFT = 'left';
     const JOIN_RIGHT = 'right';
-    const JOIN_OUTER_RIGHT = 'right outer';
-    const JOIN_OUTER_LEFT  = 'left outer';
+    const JOIN_RIGHT_OUTER = 'right outer';
+    const JOIN_LEFT_OUTER  = 'left outer';
     const SQL_STAR = '*';
     const ORDER_ASCENDING = 'ASC';
     const ORDER_DESCENDING = 'DESC';
@@ -51,6 +51,18 @@ class Select extends AbstractPreparableSql
     const COMBINE_EXCEPT = 'except';
     const COMBINE_INTERSECT = 'intersect';
     /**#@-*/
+
+    /**
+     * @const
+     * @deprecated use JOIN_LEFT_OUTER instead
+     */
+    const JOIN_OUTER_LEFT  = 'outer left';
+
+    /**
+     * @const
+     * @deprecated use JOIN_LEFT_OUTER instead
+     */
+    const JOIN_OUTER_RIGHT = 'outer right';
 
     /**
      * @var array Specifications

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -41,8 +41,8 @@ class Select extends AbstractPreparableSql
     const JOIN_OUTER = 'outer';
     const JOIN_LEFT = 'left';
     const JOIN_RIGHT = 'right';
-    const JOIN_OUTER_RIGHT = 'outer right';
-    const JOIN_OUTER_LEFT  = 'outer left';
+    const JOIN_OUTER_RIGHT = 'right outer';
+    const JOIN_OUTER_LEFT  = 'left outer';
     const SQL_STAR = '*';
     const ORDER_ASCENDING = 'ASC';
     const ORDER_DESCENDING = 'DESC';


### PR DESCRIPTION
Simple replacement of the values according to #26.

Theses values have been there since e6ad68226c0ee2d89181c2aecc92e7e56ca464e7 and names have been changed in ecdf83ed1002ad52c617ed024f6e00dc8d9c63b2. Changing back to `JOIN_LEFT_OUTER ` and `JOIN_RIGHT_OUTER ` would have been meaningful but not done here because of the BC break it involves.