### PR TITLE
Allow null $parameters in Predicate::expression()

### DIFF
--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -242,7 +242,7 @@ class Predicate extends PredicateSet
      * @param $parameters
      * @return $this
      */
-    public function expression($expression, $parameters)
+    public function expression($expression, $parameters = null)
     {
         $this->addPredicate(
             new Expression($expression, $parameters),

--- a/test/Sql/Predicate/PredicateTest.php
+++ b/test/Sql/Predicate/PredicateTest.php
@@ -228,6 +228,19 @@ class PredicateTest extends TestCase
             $predicate->getExpressionData()
         );
     }
+            
+    /**
+     * @testdox Unit test: Test expression() allows null $parameters
+     */
+    public function testExpressionNullParameters()
+    {
+        $predicate = new Predicate;
+
+        $predicate->expression('foo = bar');
+        $predicates = $predicate->getPredicates();
+        $expression = $predicates[0][1];
+        $this->assertEquals([null], $expression->getParameters());
+    }
 
     /**
      * @testdox Unit test: Test literal() is chainable, returns proper values, and is backwards compatible with 2.0.*


### PR DESCRIPTION
Zend\Db\Sql\Predicate\Expression::__construct() allows nulls for the `$valueParameter`, but this method that passes the parameter through does not allow nulls, so you have to explicitly pass null. Instead, in Zend\Db\Sql\Predicate\Predicate::expression(), the `$parameters` parameter should allow nulls.