### PR TITLE
Fix for fetching constraint data from Oracle

### DIFF
--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -124,14 +124,14 @@ class OracleMetadata extends AbstractSource
                 AND cc2.position = cc1.position
 
             WHERE
-                ac.owner = :schema AND ac.table_name = :table
+                ac.owner = :ownername AND ac.table_name = :tablename
 
-            ORDER BY ac.constraint_name;
+            ORDER BY ac.constraint_name
         ';
 
         $parameters = [
-            ':schema' => $schema,
-            ':table' => $table
+            ':ownername' => $schema,
+            ':tablename' => $table
         ];
 
         $results = $this->adapter->query($sql)->execute($parameters);

--- a/test/Metadata/Source/OracleMetadataTest.php
+++ b/test/Metadata/Source/OracleMetadataTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Metadata\Source;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Metadata\Source\OracleMetadata;
+use ZendTest\Db\Adapter\Driver\Oci8\AbstractIntegrationTest;
+
+/**
+ * @requires extension oci8
+ */
+class OracleMetadataTest extends AbstractIntegrationTest
+{
+    /**
+     * @var OracleMetadata
+     */
+    protected $metadata;
+
+    /**
+     * @var Adapter
+     */
+    protected $adapter;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        if (!extension_loaded('oci8')) {
+            $this->markTestSkipped('I cannot test without the oci8 extension');
+        }
+        parent::setUp();
+        $this->variables['driver'] = 'OCI8';
+        $this->adapter = new Adapter($this->variables);
+        $this->metadata = new OracleMetadata($this->adapter);
+    }
+
+    public function testGetConstraints()
+    {
+        $constraints = $this->metadata->getConstraints(null, 'main');
+        $this->assertCount(0, $constraints);
+        $this->assertContainsOnlyInstancesOf(
+            'Zend\Db\Metadata\Object\ConstraintObject',
+            $constraints
+        );
+    }
+}


### PR DESCRIPTION
Here's a PR to fix fetching constrain data from Oracle (now with a test)