### PR TITLE
Pin zend-stdlib to >=2.5.0,<2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-mvc": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
To ensure hydrators will work across the board, following the addition of the zend-hydrator library.