### PR TITLE
Move EventFeature constants into separate interface

### DIFF
--- a/src/Adapter/Driver/Oci8/Result.php
+++ b/src/Adapter/Driver/Oci8/Result.php
@@ -42,7 +42,7 @@ class Result implements Iterator, ResultInterface
      * @var bool
      */
     protected $currentComplete = false;
-    
+
     /**
      * @var bool
      */

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -19,7 +19,7 @@ use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Sql\Update;
 use Zend\Db\Sql\Where;
-use Zend\Db\TableGateway\Feature\EventFeatureEventsInterface as EventFeature;
+use Zend\Db\TableGateway\Feature\EventFeatureEventsInterface;
 
 /**
  *
@@ -95,7 +95,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         }
 
         $this->featureSet->setTableGateway($this);
-        $this->featureSet->apply(EventFeature::EVENT_PRE_INITIALIZE, []);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_PRE_INITIALIZE, []);
 
         if (!$this->adapter instanceof AdapterInterface) {
             throw new Exception\RuntimeException('This table does not have an Adapter setup');
@@ -113,7 +113,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
             $this->sql = new Sql($this->adapter, $this->table);
         }
 
-        $this->featureSet->apply(EventFeature::EVENT_POST_INITIALIZE, []);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_POST_INITIALIZE, []);
 
         $this->isInitialized = true;
     }
@@ -231,7 +231,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         }
 
         // apply preSelect features
-        $this->featureSet->apply(EventFeature::EVENT_PRE_SELECT, [$select]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_PRE_SELECT, [$select]);
 
         // prepare and execute
         $statement = $this->sql->prepareStatementForSqlObject($select);
@@ -242,7 +242,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $resultSet->initialize($result);
 
         // apply postSelect features
-        $this->featureSet->apply(EventFeature::EVENT_POST_SELECT, [$statement, $result, $resultSet]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_POST_SELECT, [$statement, $result, $resultSet]);
 
         return $resultSet;
     }
@@ -292,7 +292,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         }
 
         // apply preInsert features
-        $this->featureSet->apply(EventFeature::EVENT_PRE_INSERT, [$insert]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_PRE_INSERT, [$insert]);
 
         // Most RDBMS solutions do not allow using table aliases in INSERTs
         // See https://github.com/zendframework/zf2/issues/7311
@@ -308,7 +308,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $this->lastInsertValue = $this->adapter->getDriver()->getConnection()->getLastGeneratedValue();
 
         // apply postInsert features
-        $this->featureSet->apply(EventFeature::EVENT_POST_INSERT, [$statement, $result]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_POST_INSERT, [$statement, $result]);
 
         // Reset original table information in Insert instance, if necessary
         if ($unaliasedTable) {
@@ -369,13 +369,13 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         }
 
         // apply preUpdate features
-        $this->featureSet->apply(EventFeature::EVENT_PRE_UPDATE, [$update]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_PRE_UPDATE, [$update]);
 
         $statement = $this->sql->prepareStatementForSqlObject($update);
         $result = $statement->execute();
 
         // apply postUpdate features
-        $this->featureSet->apply(EventFeature::EVENT_POST_UPDATE, [$statement, $result]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_POST_UPDATE, [$statement, $result]);
 
         return $result->getAffectedRows();
     }
@@ -427,13 +427,13 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         }
 
         // pre delete update
-        $this->featureSet->apply(EventFeature::EVENT_PRE_DELETE, [$delete]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_PRE_DELETE, [$delete]);
 
         $statement = $this->sql->prepareStatementForSqlObject($delete);
         $result = $statement->execute();
 
         // apply postDelete features
-        $this->featureSet->apply(EventFeature::EVENT_POST_DELETE, [$statement, $result]);
+        $this->featureSet->apply(EventFeatureEventsInterface::EVENT_POST_DELETE, [$statement, $result]);
 
         return $result->getAffectedRows();
     }

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -19,7 +19,7 @@ use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Sql\Update;
 use Zend\Db\Sql\Where;
-use Zend\Db\TableGateway\Feature\EventFeature;
+use Zend\Db\TableGateway\Feature\EventFeatureEventsInterface as EventFeature;
 
 /**
  *
@@ -512,8 +512,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $this->sql = clone $this->sql;
         if (is_object($this->table)) {
             $this->table = clone $this->table;
-        } elseif (
-            is_array($this->table)
+        } elseif (is_array($this->table)
             && count($this->table) == 1
             && is_object(reset($this->table))
         ) {

--- a/src/TableGateway/Feature/EventFeature.php
+++ b/src/TableGateway/Feature/EventFeature.php
@@ -20,23 +20,10 @@ use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventsCapableInterface;
 
-class EventFeature extends AbstractFeature implements EventsCapableInterface
+class EventFeature extends AbstractFeature implements
+    EventFeatureEventsInterface,
+    EventsCapableInterface
 {
-    const EVENT_PRE_INITIALIZE  = 'preInitialize';
-    const EVENT_POST_INITIALIZE = 'postInitialize';
-
-    const EVENT_PRE_SELECT      = 'preSelect';
-    const EVENT_POST_SELECT     = 'postSelect';
-
-    const EVENT_PRE_INSERT      = 'preInsert';
-    const EVENT_POST_INSERT     = 'postInsert';
-
-    const EVENT_PRE_DELETE      = 'preDelete';
-    const EVENT_POST_DELETE     = 'postDelete';
-
-    const EVENT_PRE_UPDATE      = 'preUpdate';
-    const EVENT_POST_UPDATE     = 'postUpdate';
-
     /**
      * @var EventManagerInterface
      */

--- a/src/TableGateway/Feature/EventFeatureEventsInterface.php
+++ b/src/TableGateway/Feature/EventFeatureEventsInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\TableGateway\Feature;
+
+/**
+ * EventFeature event constants.
+ *
+ * This moves the constants introduced in {@link https://github.com/zendframework/zf2/pull/7066}
+ * into a separate interface that EventFeature implements; the change keeps
+ * backwards compatibility, while simultaneously removing the need to add
+ * another hard dependency to the component.
+ */
+interface EventFeatureEventsInterface
+{
+    const EVENT_PRE_INITIALIZE  = 'preInitialize';
+    const EVENT_POST_INITIALIZE = 'postInitialize';
+
+    const EVENT_PRE_SELECT      = 'preSelect';
+    const EVENT_POST_SELECT     = 'postSelect';
+
+    const EVENT_PRE_INSERT      = 'preInsert';
+    const EVENT_POST_INSERT     = 'postInsert';
+
+    const EVENT_PRE_DELETE      = 'preDelete';
+    const EVENT_POST_DELETE     = 'postDelete';
+
+    const EVENT_PRE_UPDATE      = 'preUpdate';
+    const EVENT_POST_UPDATE     = 'postUpdate';
+}


### PR DESCRIPTION
This patch moves the EventFeature event constants into a separate interface, removing the need to add a hard dependency on zend-eventmanager to the component. `EventFeature` now implements the interface, ensuring that references to the constants will continue to work, while `AbstractTableGateway` now uses the interface constants instead (ensuring that the zend-eventmanager dependency is not raised during usage).

Resolves #25 without requiring a new dependency.