### PR TITLE
Update to use zend-hydrator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,19 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "~2.5",
+        "zendframework/zend-hydrator": "~1.0",
         "zendframework/zend-mvc": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
-        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "Zend\\EventManager component",
+        "zendframework/zend-hydrator": "Zend\\Hydrator component for using HydratingResultSets",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
     },
     "minimum-stability": "dev",

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -10,8 +10,8 @@
 namespace Zend\Db\ResultSet;
 
 use ArrayObject;
-use Zend\Stdlib\Hydrator\ArraySerializable;
-use Zend\Stdlib\Hydrator\HydratorInterface;
+use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\HydratorInterface;
 
 class HydratingResultSet extends AbstractResultSet
 {

--- a/test/ResultSet/HydratingResultSetTest.php
+++ b/test/ResultSet/HydratingResultSetTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Db\ResultSet;
 
 use Zend\Db\ResultSet\HydratingResultSet;
+use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\ClassMethods;
 
 class HydratingResultSetTest extends \PHPUnit_Framework_TestCase
 {
@@ -38,7 +40,7 @@ class HydratingResultSetTest extends \PHPUnit_Framework_TestCase
     public function testSetHydrator()
     {
         $hydratingRs = new HydratingResultSet;
-        $this->assertSame($hydratingRs, $hydratingRs->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods()));
+        $this->assertSame($hydratingRs, $hydratingRs->setHydrator(new ClassMethods()));
     }
 
     /**
@@ -47,7 +49,7 @@ class HydratingResultSetTest extends \PHPUnit_Framework_TestCase
     public function testGetHydrator()
     {
         $hydratingRs = new HydratingResultSet;
-        $this->assertInstanceOf('Zend\Stdlib\Hydrator\ArraySerializable', $hydratingRs->getHydrator());
+        $this->assertInstanceOf(ArraySerializable::class, $hydratingRs->getHydrator());
     }
 
     /**


### PR DESCRIPTION
This patch updates the develop branch (future 2.6.0) to use zend-hydrator for hydrator functionality. This is backwards compatible, as all zend-stdlib hydrators will fulfill the same interfaces, but provides forwards compatibility with hydrators written using the zend-hydrator interfaces.