### PR TITLE
Fix isset on null values

### DIFF
--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -243,7 +243,7 @@ class Insert extends AbstractPreparableSql
      */
     public function __isset($name)
     {
-        return isset($this->columns[$name]);
+        return array_key_exists($name, $this->columns);
     }
 
     /**

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -226,7 +226,7 @@ class Insert extends AbstractPreparableSql
      */
     public function __unset($name)
     {
-        if (!isset($this->columns[$name])) {
+        if (!$this->__isset($name)) {
             throw new Exception\InvalidArgumentException('The key ' . $name . ' was not found in this objects column list');
         }
 
@@ -257,7 +257,7 @@ class Insert extends AbstractPreparableSql
      */
     public function __get($name)
     {
-        if (!isset($this->columns[$name])) {
+        if (!$this->__isset($name)) {
             throw new Exception\InvalidArgumentException('The key ' . $name . ' was not found in this objects column list');
         }
         return $this->columns[$name];

--- a/test/Sql/InsertTest.php
+++ b/test/Sql/InsertTest.php
@@ -243,6 +243,14 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         unset($this->insert->foo);
         $this->assertEquals([], $this->insert->getRawState('columns'));
         $this->assertEquals([], $this->insert->getRawState('values'));
+
+        $this->insert->foo = NULL;
+        $this->assertEquals(['foo'], $this->insert->getRawState('columns'));
+        $this->assertEquals([NULL], $this->insert->getRawState('values'));
+
+        unset($this->insert->foo);
+        $this->assertEquals([], $this->insert->getRawState('columns'));
+        $this->assertEquals([], $this->insert->getRawState('values'));
     }
 
     /**
@@ -251,6 +259,9 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function test__isset()
     {
         $this->insert->foo = 'bar';
+        $this->assertTrue(isset($this->insert->foo));
+
+        $this->insert->foo = NULL;
         $this->assertTrue(isset($this->insert->foo));
     }
 
@@ -261,6 +272,9 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     {
         $this->insert->foo = 'bar';
         $this->assertEquals('bar', $this->insert->foo);
+
+        $this->insert->foo = NULL;
+        $this->assertNull($this->insert->foo);
     }
 
     /**


### PR DESCRIPTION
PHP `isset` returns false when array item value is `NULL`. This resulted in `__unset` throwing an exception when attempting to remove a null field from the insert clause.