### PR TITLE
Implement FeatureSet canCallMagicCall and callMagicCall methods

### DIFF
--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -125,22 +125,36 @@ class FeatureSet
     }
 
     /**
+     * Is the method requested available in one of the added features
      * @param string $method
      * @return bool
      */
     public function canCallMagicCall($method)
     {
+        if (!empty($this->features)) {
+            foreach ($this->features as $feature) {
+                if (method_exists($feature, $method)) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 
     /**
+     * Call method of on added feature as though it were a local method
      * @param string $method
      * @param array $arguments
      * @return mixed
      */
     public function callMagicCall($method, $arguments)
     {
-        $return = null;
-        return $return;
+        foreach ($this->features as $feature) {
+            if (method_exists($feature, $method)) {
+                return $feature->$method($arguments);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -155,6 +155,6 @@ class FeatureSet
             }
         }
 
-        return null;
+        return;
     }
 }

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -14,6 +14,7 @@ use Zend\Db\TableGateway\Feature\MasterSlaveFeature;
 use Zend\Db\TableGateway\Feature\SequenceFeature;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
 use Zend\Db\Metadata\Object\ConstraintObject;
+use \ReflectionClass;
 
 class FeatureSetTest extends \PHPUnit_Framework_TestCase
 {
@@ -156,7 +157,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $reflectionClass = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $reflectionClass = new ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
         $reflectionProperty = $reflectionClass->getProperty('adapter');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($tableGatewayMock, $adapterMock);

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Db\TableGateway\Feature;
 
 use Zend\Db\TableGateway\Feature\FeatureSet;
 use Zend\Db\TableGateway\Feature\MasterSlaveFeature;
+use Zend\Db\TableGateway\Feature\SequenceFeature;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
 use Zend\Db\Metadata\Object\ConstraintObject;
 
@@ -20,7 +21,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
      * @cover FeatureSet::addFeature
      * @group ZF2-4993
      */
-    public function testAddFeatureThatFeatureDoesnotHasTableGatewayButFeatureSetHas()
+    public function testAddFeatureThatFeatureDoesNotHaveTableGatewayButFeatureSetHas()
     {
         $mockMasterAdapter = $this->getMock('Zend\Db\Adapter\AdapterInterface');
 
@@ -57,7 +58,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
      * @cover FeatureSet::addFeature
      * @group ZF2-4993
      */
-    public function testAddFeatureThatFeatureHasTableGatewayButFeatureSetDoesnotHas()
+    public function testAddFeatureThatFeatureHasTableGatewayButFeatureSetDoesNotHave()
     {
         $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
 
@@ -76,5 +77,94 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
 
         $featureSet = new FeatureSet;
         $this->assertInstanceOf('Zend\Db\TableGateway\Feature\FeatureSet', $featureSet->addFeature($feature));
+    }
+
+    /**
+     * @cover FeatureSet::canCallMagicCall
+     */
+    public function testCanCallMagicCallReturnsTrueForAddedMethodOfAddedFeature()
+    {
+        $feature = new SequenceFeature('id', 'table_sequence');
+        $featureSet = new FeatureSet;
+        $featureSet->addFeature($feature);
+
+        $this->assertTrue(
+            $featureSet->canCallMagicCall('lastSequenceId'),
+            "Should have been able to call lastSequenceId from the Sequence Feature"
+        );
+    }
+
+    /**
+     * @cover FeatureSet::canCallMagicCall
+     */
+    public function testCanCallMagicCallReturnsFalseForAddedMethodOfAddedFeature()
+    {
+        $feature = new SequenceFeature('id', 'table_sequence');
+        $featureSet = new FeatureSet;
+        $featureSet->addFeature($feature);
+
+        $this->assertFalse(
+            $featureSet->canCallMagicCall('postInitialize'),
+            "Should have been able to call postInitialize from the MetaData Feature"
+        );
+    }
+
+    /**
+     * @cover FeatureSet::canCallMagicCall
+     */
+    public function testCanCallMagicCallReturnsFalseWhenNoFeaturesHaveBeenAdded()
+    {
+        $featureSet = new FeatureSet;
+        $this->assertFalse(
+            $featureSet->canCallMagicCall('lastSequenceId')
+        );
+    }
+
+    /**
+     * @cover FeatureSet::callMagicCall
+     */
+    public function testCallMagicCallSucceedsForValidMethodOfAddedFeature()
+    {
+        $sequenceName = 'table_sequence';
+
+        $platformMock = $this->getMock('Zend\Db\Adapter\Platform\Postgresql');
+        $platformMock->expects($this->any())
+            ->method('getName')->will($this->returnValue('PostgreSQL'));
+
+        $resultMock = $this->getMock('Zend\Db\Adapter\Driver\Pgsql\Result');
+        $resultMock->expects($this->any())
+            ->method('current')
+            ->will($this->returnValue(['currval' => 1]));
+
+        $statementMock = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statementMock->expects($this->any())
+            ->method('prepare')
+            ->with('SELECT CURRVAL(\'' . $sequenceName . '\')');
+        $statementMock->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue($resultMock));
+
+        $adapterMock = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterMock->expects($this->any())
+            ->method('getPlatform')->will($this->returnValue($platformMock));
+        $adapterMock->expects($this->any())
+            ->method('createStatement')->will($this->returnValue($statementMock));
+
+        $tableGatewayMock = $this->getMockBuilder('Zend\Db\TableGateway\AbstractTableGateway')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $reflectionClass = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        $reflectionProperty = $reflectionClass->getProperty('adapter');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($tableGatewayMock, $adapterMock);
+
+        $feature = new SequenceFeature('id', 'table_sequence');
+        $feature->setTableGateway($tableGatewayMock);
+        $featureSet = new FeatureSet;
+        $featureSet->addFeature($feature);
+        $this->assertEquals(1, $featureSet->callMagicCall('lastSequenceId', null));
     }
 }

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -80,7 +80,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @cover FeatureSet::canCallMagicCall
+     * @covers Zend\Db\TableGateway\Feature\FeatureSet::canCallMagicCall
      */
     public function testCanCallMagicCallReturnsTrueForAddedMethodOfAddedFeature()
     {
@@ -95,7 +95,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @cover FeatureSet::canCallMagicCall
+     * @covers Zend\Db\TableGateway\Feature\FeatureSet::canCallMagicCall
      */
     public function testCanCallMagicCallReturnsFalseForAddedMethodOfAddedFeature()
     {
@@ -110,7 +110,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @cover FeatureSet::canCallMagicCall
+     * @covers Zend\Db\TableGateway\Feature\FeatureSet::canCallMagicCall
      */
     public function testCanCallMagicCallReturnsFalseWhenNoFeaturesHaveBeenAdded()
     {
@@ -121,7 +121,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @cover FeatureSet::callMagicCall
+     * @covers Zend\Db\TableGateway\Feature\FeatureSet::callMagicCall
      */
     public function testCallMagicCallSucceedsForValidMethodOfAddedFeature()
     {

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -9,12 +9,12 @@
 
 namespace ZendTest\Db\TableGateway\Feature;
 
+use ReflectionClass;
 use Zend\Db\TableGateway\Feature\FeatureSet;
 use Zend\Db\TableGateway\Feature\MasterSlaveFeature;
 use Zend\Db\TableGateway\Feature\SequenceFeature;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
 use Zend\Db\Metadata\Object\ConstraintObject;
-use \ReflectionClass;
 
 class FeatureSetTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Recently, I was attempting to call the lastSequenceId method of the
SequenceFeature, after adding the SequenceFeature to a TableGateway
object. However, on doing so, I discovered that both methods effectively
weren't implemented, despite what the manual alluded to. Given that I'm
adding this commit, along with the covering tests to implement the
functionality.