### PR TITLE
Allow unix_socket parameter, throw exception if both hostname and unix_socket set

### DIFF
--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -213,6 +213,13 @@ class Connection extends AbstractConnection
             }
         }
 
+        if (isset($hostname) && isset($unix_socket)) {
+            throw new Exception\InvalidConnectionParametersException(
+                'Ambiguous connection parameters, both hostname and unix_socket parameters were set',
+                $this->connectionParameters
+            );
+        }
+
         if (!isset($dsn) && isset($pdoDriver)) {
             $dsn = [];
             switch ($pdoDriver) {

--- a/test/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/test/Adapter/Driver/Pdo/ConnectionTest.php
@@ -63,7 +63,6 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->setConnectionParameters([
             'driver'  => 'pdo_mysql',
-            'host'    => '127.0.0.1',
             'charset' => 'utf8',
             'dbname'  => 'foo',
             'port'    => '3306',
@@ -76,10 +75,26 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $responseString = $this->connection->getDsn();
 
         $this->assertStringStartsWith('mysql:', $responseString);
-        $this->assertContains('host=127.0.0.1', $responseString);
         $this->assertContains('charset=utf8', $responseString);
         $this->assertContains('dbname=foo', $responseString);
         $this->assertContains('port=3306', $responseString);
         $this->assertContains('unix_socket=/var/run/mysqld/mysqld.sock', $responseString);
+    }
+
+    public function testHostnameAndUnixSocketThrowsInvalidConnectionParametersException()
+    {
+        $this->setExpectedException(
+            'Zend\Db\Adapter\Exception\InvalidConnectionParametersException',
+            'Ambiguous connection parameters, both hostname and unix_socket parameters were set'
+        );
+
+        $this->connection->setConnectionParameters([
+            'driver'  => 'pdo_mysql',
+            'host'    => '127.0.0.1',
+            'dbname'  => 'foo',
+            'port'    => '3306',
+            'unix_socket' => '/var/run/mysqld/mysqld.sock',
+        ]);
+        $this->connection->connect();
     }
 }


### PR DESCRIPTION
This PR supersedes PR #48 and fixes issue #47 

The main issue is that in the PDO MySQL adapter, if you want to connect via socket you need to pass the unix_socket parameter to PDO vs. a hostname parameter.  If both are set, it is ambiguous and is described in the PHP manual.  An exception will be thrown in this case.