### PR TITLE
Refactor Zend\Db\Sql\Ddl\Index\Index constructor

### DIFF
--- a/src/Sql/Ddl/Index/Index.php
+++ b/src/Sql/Ddl/Index/Index.php
@@ -22,13 +22,13 @@ class Index extends AbstractIndex
     protected $lengths;
 
     /**
-     * @param  string $column
+     * @param  string|array|null $columns
      * @param  null|string $name
      * @param array $lengths
      */
-    public function __construct($column, $name = null, array $lengths = [])
+    public function __construct($columns, $name = null, array $lengths = [])
     {
-        $this->setColumns($column);
+        $this->setColumns($columns);
 
         $this->name    = null === $name ? null : (string) $name;
         $this->lengths = $lengths;


### PR DESCRIPTION
Refactored the name of the constructor's first argument and it's documentation to be in line with the `setColumns()` method which it's passed to. I came across this whilst debugging an `AlterTable` object which was attempting to add an Index to a PostgreSQL table. 