### PR TITLE
Configuring PostgreSQL charset

### DIFF
--- a/.ci/pgsql_fixtures.sh
+++ b/.ci/pgsql_fixtures.sh
@@ -3,3 +3,4 @@
 echo "Configure PostgreSQL test database"
 
 psql -U postgres -c 'create database zenddb_test;'
+psql -U postgres -c "alter role postgres password 'postgres'"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,7 +61,7 @@
 
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_USERNAME" value="postgres" />
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_PASSWORD" value="" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_PASSWORD" value="postgres" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_DATABASE" value="zenddb_test" />
 
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLITE_MEMORY" value="true" />

--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -136,6 +136,18 @@ class Connection extends AbstractConnection
             ));
         }
 
+        $p = $this->connectionParameters;
+
+        if (!empty($p['charset'])) {
+            if (-1 === pg_set_client_encoding($this->resource, $p['charset'])) {
+                throw new Exception\RuntimeException(sprintf(
+                    "%s: Unable to set client encoding '%s'",
+                    __METHOD__,
+                    $p['charset']
+                ));
+            }
+        }
+
         return $this;
     }
 

--- a/test/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -126,7 +126,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'post'     => '5432',
             'dbname'   => 'zenddb_test',
             'username' => 'postgres',
-            'password' => '',
+            'password' => 'postgres',
             'charset'  => 'SQL_ASCII',
         ));
 
@@ -149,7 +149,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'post'     => '5432',
             'dbname'   => 'zenddb_test',
             'username' => 'postgres',
-            'password' => '',
+            'password' => 'postgres',
             'charset'  => 'FOOBAR',
         ));
 

--- a/test/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -120,7 +120,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('pgsql extension not loaded');
         }
 
-        $this->connection->setConnectionParameters(array(
+        $this->connection->setConnectionParameters([
             'driver'   => 'pgsql',
             'host'     => 'localhost',
             'post'     => '5432',
@@ -128,7 +128,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'username' => 'postgres',
             'password' => 'postgres',
             'charset'  => 'SQL_ASCII',
-        ));
+        ]);
 
         $this->connection->connect();
 
@@ -143,7 +143,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');
 
-        $this->connection->setConnectionParameters(array(
+        $this->connection->setConnectionParameters([
             'driver'   => 'pgsql',
             'host'     => 'localhost',
             'post'     => '5432',
@@ -151,7 +151,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'username' => 'postgres',
             'password' => 'postgres',
             'charset'  => 'FOOBAR',
-        ));
+        ]);
 
         $this->connection->connect();
     }

--- a/test/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -113,4 +113,46 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->connection->setType($type);
         $this->assertEquals($type, self::readAttribute($this->connection, 'type'));
     }
+
+    public function testSetCharset()
+    {
+        if (! extension_loaded('pgsql')) {
+            $this->markTestSkipped('pgsql extension not loaded');
+        }
+
+        $this->connection->setConnectionParameters(array(
+            'driver'   => 'pgsql',
+            'host'     => 'localhost',
+            'post'     => '5432',
+            'dbname'   => 'zenddb_test',
+            'username' => 'postgres',
+            'password' => '',
+            'charset'  => 'SQL_ASCII',
+        ));
+
+        $this->connection->connect();
+
+        $this->assertEquals('SQL_ASCII', pg_client_encoding($this->connection->getResource()));
+    }
+
+    public function testSetInvalidCharset()
+    {
+        if (! extension_loaded('pgsql')) {
+            $this->markTestSkipped('pgsql extension not loaded');
+        }
+
+        $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');
+
+        $this->connection->setConnectionParameters(array(
+            'driver'   => 'pgsql',
+            'host'     => 'localhost',
+            'post'     => '5432',
+            'dbname'   => 'zenddb_test',
+            'username' => 'postgres',
+            'password' => '',
+            'charset'  => 'FOOBAR',
+        ));
+
+        $this->connection->connect();
+    }
 }


### PR DESCRIPTION
I just enabled the charset configuration to PostgreSQL, like I said in issue #70.

In the second commit, I just configure the `postgres` password to enable authentication, because I received an `PDOException` to an empty password.

```
PHP Fatal error:  Uncaught exception 'PDOException' with message 'SQLSTATE[08006] [7] fe_sendauth: no password supplied' in /vagrant/test/IntegrationTestListener.php:63
```