### PR TITLE
Changed Vagrantfile to reflect box rename to bento from chef

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ fi
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = 'chef/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-14.04'
 
   # MySQL port
   config.vm.network 'forwarded_port', guest: 3306, host: 3306, auto_correct: true


### PR DESCRIPTION
The `vagrant up` command was reporting it needed a name change from: 
Requested name: `chef/ubuntu-14.04` to Actual name: `bento/ubuntu-14.04`
This PR makes that change.