### PR TITLE
Refactor Insert::values() method to properly merge values with columns

### DIFF
--- a/test/Sql/InsertTest.php
+++ b/test/Sql/InsertTest.php
@@ -49,8 +49,9 @@ class InsertTest extends \PHPUnit_Framework_TestCase
      */
     public function testColumns()
     {
-        $this->insert->columns(['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar'], $this->insert->getRawState('columns'));
+        $columns = ['foo', 'bar'];
+        $this->insert->columns($columns);
+        $this->assertEquals($columns, $this->insert->getRawState('columns'));
     }
 
     /**
@@ -218,8 +219,23 @@ class InsertTest extends \PHPUnit_Framework_TestCase
 
         // with Select and columns
         $this->insert->columns(['col1', 'col2']);
+        $this->assertEquals(
+            'INSERT INTO "foo" ("col1", "col2") SELECT "bar".* FROM "bar"',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+    }
 
-        $this->assertEquals('INSERT INTO "foo" ("col1", "col2") SELECT "bar".* FROM "bar"', $this->insert->getSqlString(new TrustingSql92Platform()));
+    public function testGetSqlStringUsingColumnsAndValuesMethods()
+    {
+        // With columns() and values()
+        $this->insert
+            ->into('foo')
+            ->columns(['col1', 'col2', 'col3'])
+            ->values(['val1', 'val2', 'val3']);
+        $this->assertEquals(
+            'INSERT INTO "foo" ("col1", "col2", "col3") VALUES (\'val1\', \'val2\', \'val3\')',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
     }
 
     /**


### PR DESCRIPTION
When attempting to use both columns() and values() together to set the columns and value for an insert object, and when passing non-associative arrays to both, as seems logically correct to be able to do,
the generated SQL query has the numeric keys of the values array overwrite the columns set from the array passed to columns(). 

What I would expect is that the two were properly combined. This minor
fix does that, and leaves the remaining functionality in place. For example, I'd expect that if I had the following:

```php
$this->insert
    ->into('foo')
    ->columns(['col1', 'col2', 'col3'])
    ->values(['val1', 'val2', 'val3']);
```

That the generated SQL would be:

```sql
INSERT INTO foo ("col1", "col2", "col3") VALUES("val1", "val2", "val3");
```

Without this patch, the generated SQL would be:

```sql
INSERT INTO foo ("0", "1", "2") VALUES("val1", "val2", "val3");
```