### PR TITLE
Extended test matrix for #85

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ before_install:
   - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^2.1" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - $(echo "composer.json to install:" && cat composer.json)
+  - echo "composer.json to install:"
+  - cat composer.json
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ before_install:
   - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^2.1" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - $(echo "composer.json to install:" && cat composer.json)
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - EVENT_MANAGER_VERSION='^2.6.2'
+        - EVENT_MANAGER_VERSION:'^2.6.2'
         - HYDRATOR_VERSION='^1.1'
         - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
@@ -63,8 +63,8 @@ before_install:
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
   - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --no-update "zendframework/zend-stdlib:^2.7" ; fi
-  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$HYDRATOR_VERSION" ; fi
-  - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^2.1" ; fi
+  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-hydrator:$HYDRATOR_VERSION" ; fi
+  - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-hydrator:^2.1" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
   - echo "composer.json to install:"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,26 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+        - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
+        - PATH="$HOME/.local/bin:$PATH"
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 7
-    - php: hhvm 
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION='^2.7.5'
+    - php: hhvm
+    - php: hhvm
+      env:
+        - SERVICE_MANAGER_VERSION='^2.7.5'
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -39,6 +52,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update "zendframework/zend-i18n" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
+        - EVENT_MANAGER_VERSION='^2.6.2'
+        - HYDRATOR_VERSION='^1.1'
         - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
       env:
@@ -32,14 +34,20 @@ matrix:
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
+        - EVENT_MANAGER_VERSION='^2.6.2'
+        - HYDRATOR_VERSION='^1.1'
         - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 7
     - php: 7
       env:
+        - EVENT_MANAGER_VERSION='^2.6.2'
+        - HYDRATOR_VERSION='^1.1'
         - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: hhvm
     - php: hhvm
       env:
+        - EVENT_MANAGER_VERSION='^2.6.2'
+        - HYDRATOR_VERSION='^1.1'
         - SERVICE_MANAGER_VERSION='^2.7.5'
   allow_failures:
     - php: hhvm
@@ -52,9 +60,13 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
+  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --no-update "zendframework/zend-stdlib:^3.0" ; fi
+  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$HYDRATOR_VERSION" ; fi
+  - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^2.1" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update "zendframework/zend-i18n" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
-  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --no-update "zendframework/zend-stdlib:^3.0" ; fi
+  - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --no-update "zendframework/zend-stdlib:^2.7" ; fi
   - if [[ $HYDRATOR_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$HYDRATOR_VERSION" ; fi
   - if [[ $HYDRATOR_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^2.1" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,12 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^2.6|^3.0",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-hydrator": "~1.0",
-        "zendframework/zend-mvc": "dev-develop as 2.7.0",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-hydrator": "~1.0",
+        "zendframework/zend-hydrator": "^1.1 || ^2.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"

--- a/src/Adapter/AdapterAbstractServiceFactory.php
+++ b/src/Adapter/AdapterAbstractServiceFactory.php
@@ -10,7 +10,8 @@
 namespace Zend\Db\Adapter;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Database adapter abstract service factory.
@@ -31,7 +32,7 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
      * @param  string $requestedName
      * @return bool
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         $config = $this->getConfig($container);
         if (empty($config)) {
@@ -46,6 +47,19 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
+     * Determine if we can create a service with name (SM v2 compatibility)
+     *
+     * @param serviceLocator $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return $this->canCreate($serviceLocator, $requestedName);
+    }
+
+    /**
      * Create a DB adapter
      *
      * @param  ContainerInterface $container
@@ -57,6 +71,19 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
     {
         $config = $this->getConfig($container);
         return new Adapter($config[$requestedName]);
+    }
+
+    /**
+     * Create service with name
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name
+     * @param string $requestedName
+     * @return Adapter
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return $this($serviceLocator, $requestedName);
     }
 
     /**

--- a/src/Adapter/AdapterServiceFactory.php
+++ b/src/Adapter/AdapterServiceFactory.php
@@ -10,7 +10,7 @@
 namespace Zend\Db\Adapter;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AdapterServiceFactory implements FactoryInterface

--- a/src/Adapter/AdapterServiceFactory.php
+++ b/src/Adapter/AdapterServiceFactory.php
@@ -11,6 +11,7 @@ namespace Zend\Db\Adapter;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AdapterServiceFactory implements FactoryInterface
 {
@@ -24,5 +25,16 @@ class AdapterServiceFactory implements FactoryInterface
     {
         $config = $container->get('config');
         return new Adapter($config['db']);
+    }
+
+    /**
+     * Create db adapter service (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @return Adapter
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, Adapter::class);
     }
 }

--- a/test/Adapter/AdapterAbstractServiceFactoryTest.php
+++ b/test/Adapter/AdapterAbstractServiceFactoryTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Db\Adapter;
 
 use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Config;
 
 class AdapterAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,9 +26,12 @@ class AdapterAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->serviceManager = new ServiceManager([
-            'abstract_factories' => ['Zend\Db\Adapter\AdapterAbstractServiceFactory'],
+        $this->serviceManager = new ServiceManager();
+
+        $config = new Config([
+            'abstract_factories' => ['Zend\Db\Adapter\AdapterAbstractServiceFactory']
         ]);
+        $config->configureServiceManager($this->serviceManager);
 
         $this->serviceManager->setService('config', [
             'db' => [

--- a/test/Adapter/AdapterServiceFactoryTest.php
+++ b/test/Adapter/AdapterServiceFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Adapter;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterServiceFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AdapterServiceFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        if (! extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('Adapter factory tests require pdo_sqlite');
+        }
+
+        $this->services = $this->prophesize(ServiceLocatorInterface::class);
+        $this->services->willImplement(ContainerInterface::class);
+
+        $this->factory = new AdapterServiceFactory();
+    }
+
+    public function testV2FactoryReturnsAdapter()
+    {
+        $this->services->get('config')->willReturn([
+            'db' => [
+                'driver' => 'Pdo_Sqlite',
+                'database' => 'sqlite::memory:',
+            ],
+        ]);
+
+        $adapter = $this->factory->createService($this->services->reveal());
+        $this->assertInstanceOf(Adapter::class, $adapter);
+    }
+
+    public function testV3FactoryReturnsAdapter()
+    {
+        $this->services->get('config')->willReturn([
+            'db' => [
+                'driver' => 'Pdo_Sqlite',
+                'database' => 'sqlite::memory:',
+            ],
+        ]);
+
+        $adapter = $this->factory->__invoke($this->services->reveal(), Adapter::class);
+        $this->assertInstanceOf(Adapter::class, $adapter);
+    }
+}


### PR DESCRIPTION
This pull request builds on #85, with the following changes:

- Allow zend-hydrator either `^1.1` or `^2.1`.
- Update the test matrix to allow testing zend-eventmanager v2 vs v3, and zend-hydrator v1.1 vs v2.1.
- Ensure that `AdapterServiceFactory` is both backwards compatible with v2 and forwards compatible with v3.