### PR TITLE
Added .ci and Vagrantfile to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,5 @@
 .travis.yml export-ignore
 .php_cs export-ignore
 phpunit.xml.dist export-ignore
-.ci export-ignore
+/.ci export-ignore
 Vagrantfile export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 .travis.yml export-ignore
 .php_cs export-ignore
 phpunit.xml.dist export-ignore
+.ci export-ignore
+Vagrantfile export-ignore


### PR DESCRIPTION
When the Repo is downloaded with composer, the Vagrantfile and .ci folder are also downloaded.
I added them to the `.gitattributes`, because they are only used for development.