### PR TITLE
Overide quoteIdentifierInFragment function in IBMDB2 platform

### DIFF
--- a/src/Adapter/Platform/IbmDb2.php
+++ b/src/Adapter/Platform/IbmDb2.php
@@ -40,7 +40,7 @@ class IbmDb2 extends AbstractPlatform
     {
         return 'IBM DB2';
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -69,7 +69,7 @@ class IbmDb2 extends AbstractPlatform
         }
         return $identifier;
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/Adapter/Platform/IbmDb2.php
+++ b/src/Adapter/Platform/IbmDb2.php
@@ -44,12 +44,12 @@ class IbmDb2 extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    public function quoteIdentifierInFragment($identifier, array $safeWords = [])
     {
         if (! $this->quoteIdentifiers) {
             return $identifier;
         }
-        $safeWordsInt = array('*' => true, ' ' => true, '.' => true, 'as' => true);
+        $safeWordsInt = ['*' => true, ' ' => true, '.' => true, 'as' => true];
         foreach ($safeWords as $sWord) {
             $safeWordsInt[strtolower($sWord)] = true;
         }

--- a/src/Adapter/Platform/IbmDb2.php
+++ b/src/Adapter/Platform/IbmDb2.php
@@ -40,7 +40,36 @@ class IbmDb2 extends AbstractPlatform
     {
         return 'IBM DB2';
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    {
+        if (! $this->quoteIdentifiers) {
+            return $identifier;
+        }
+        $safeWordsInt = array('*' => true, ' ' => true, '.' => true, 'as' => true);
+        foreach ($safeWords as $sWord) {
+            $safeWordsInt[strtolower($sWord)] = true;
+        }
+        $parts = preg_split(
+            '/([^0-9,a-z,A-Z$#_:])/i',
+            $identifier,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+        );
+        $identifier = '';
+        foreach ($parts as $part) {
+            $identifier .= isset($safeWordsInt[strtolower($part)])
+                ? $part
+                : $this->quoteIdentifier[0]
+                . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $part)
+                . $this->quoteIdentifier[1];
+        }
+        return $identifier;
+    }
+    
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
The ```quoteIdentifierInFragment``` function in the ```AbstractPlatform``` class doesn't handle the number sign # (AKA pound, hash, octothorpe symbol) in a field.  IBM i DB2 tables commonly have # in the database field name.  The only change to the function is the regex.  I've added **#** 

'/([^0-9,a-z,A-Z$**#**_:])/i',

For example the field name WE_WEQSEQ# becomes WE_WEQSEQ**"#"** after running

```
$resultSet = $this->tableGateway->select(function (Select $select) use ($data) {
$select->where($data);
$select->order("WE_WEQSEQ# DESC");
});
```
And the database gives the error "Column or global variable WE_WEQSEQ"# not found. SQLCODE=-206"


## References to AbstractPlatform:

quoteIdentifierInFragment function
https://github.com/zendframework/zend-db/blob/master/src/Adapter/Platform/AbstractPlatform.php#L32

regex used in quoteIdentifierInFragment that picks the # to be quoted
https://github.com/zendframework/zend-db/blob/master/src/Adapter/Platform/AbstractPlatform.php#L45

## Regex verified by testing here
Live Test my regex '/([^0-9,a-z,A-Z$#_:])/i',:
https://regex101.com/r/oV2wL1/3