### PR TITLE
Expose package as a config-provider / ZF component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,10 @@
         "branch-alias": {
             "dev-master": "2.7-dev",
             "dev-develop": "2.8-dev"
+        },
+        "zf": {
+            "component": "Zend\\Db",
+            "config-provider": "Zend\\Db\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db;
+
+class ConfigProvider
+{
+    /**
+     * Retrieve zend-db default configuration.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Retrieve zend-db default dependency configuration.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'abstract_factories' => [
+                Adapter\AdapterAbstractServiceFactory::class,
+            ],
+            'factories' => [
+                Adapter\AdapterInterface::class => Adapter\AdapterServiceFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db;
+
+class Module
+{
+    /**
+     * Retrieve default zend-db configuration for zend-mvc context.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+}


### PR DESCRIPTION
Adds:

- `ConfigProvider`, which maps the `AdapterInterface` service to the `AdapterServiceFactory`, and enables the `AdapterAbstractServiceFactory`.
- `Module`, which does the same for a zend-mvc context.