### PR TITLE
Fix Select joined table columns (2.8.0)

### DIFF
--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -125,7 +125,7 @@ class Join implements Iterator, Countable
                 sprintf("join() expects '%s' as a single element associative array", array_shift($name))
             );
         }
-        
+
         if ($columns === [Select::SQL_STAR] || $columns == Select::SQL_STAR) {
             $columns = [Select::SQL_STAR];
         } elseif (!is_array($columns)) {
@@ -137,8 +137,8 @@ class Join implements Iterator, Countable
             'on'      => $on,
             'columns' => $columns,
             'type'    => $type ? $type : Join::JOIN_INNER
-        ];        
-        
+        ];
+
         return $this;
     }
 

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -132,10 +132,6 @@ class Join implements Iterator, Countable
             $columns = [$columns];
         }
 
-        if (! is_array($columns)) {
-            $columns = [$columns];
-        }
-        
         $this->joins[] = [
             'name'    => $name,
             'on'      => $on,

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -125,18 +125,24 @@ class Join implements Iterator, Countable
                 sprintf("join() expects '%s' as a single element associative array", array_shift($name))
             );
         }
+        
+        if ($columns === [Select::SQL_STAR] || $columns == Select::SQL_STAR) {
+            $columns = [Select::SQL_STAR];
+        } elseif (!is_array($columns)) {
+            $columns = [$columns];
+        }
 
         if (! is_array($columns)) {
             $columns = [$columns];
         }
-
+        
         $this->joins[] = [
             'name'    => $name,
             'on'      => $on,
-            'columns' => $columns ? $columns : [Select::SQL_STAR],
+            'columns' => $columns,
             'type'    => $type ? $type : Join::JOIN_INNER
-        ];
-
+        ];        
+        
         return $this;
     }
 

--- a/test/Sql/SqlFunctionalTest.php
+++ b/test/Sql/SqlFunctionalTest.php
@@ -101,6 +101,28 @@ class SqlFunctionalTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
+            // Github issue https://github.com/zendframework/zend-db/issues/98
+            'Select::processJoinNoJoinedColumns()' => [
+                'sqlObject' => $this->select('my_table')
+                                    ->join('joined_table2', 'my_table.id = joined_table.id', $columns=[])
+                                    ->columns([
+                                        'my_table_column',
+                                    ]),
+                'expected' => [
+                    'sql92' => [
+                        'string' => 'SELECT "my_table"."my_table_column" AS "my_table_column" FROM "my_table" INNER JOIN "joined_table2" ON "my_table"."id" = "joined_table"."id"',
+                    ],
+                    'MySql' => [
+                        'string' => 'SELECT `my_table`.`my_table_column` AS `my_table_column` FROM `my_table` INNER JOIN `joined_table2` ON `my_table`.`id` = `joined_table`.`id`',
+                    ],
+                    'Oracle' => [
+                        'string' => 'SELECT "my_table"."my_table_column" AS "my_table_column" FROM "my_table" INNER JOIN "joined_table2" ON "my_table"."id" = "joined_table"."id"',
+                    ],
+                    'SqlServer' => [
+                        'string' => 'SELECT [my_table].[my_table_column] AS [my_table_column] FROM [my_table] INNER JOIN [joined_table2] ON [my_table].[id] = [joined_table].[id]',
+                    ]
+                ]
+            ],
             'Select::processJoin()' => [
                 'sqlObject' => $this->select('a')->join(['b'=>$this->select('c')->where(['cc'=>10])], 'd=e')->where(['x'=>20]),
                 'expected'  => [


### PR DESCRIPTION
Attempt to fix issue #98 

The current fix ensure the the columns of joined tables in a Select object can be excluded from sql string.

Since 2.8.0 the signature of the method join (see Join.php) has slightly changed. The default `Select::SQL_STAR` is now an array `[Select::SQL_STAR]`. 

Unfortunately the check for empty array with the ternary operator below always return SQL_STAR instead of "no columns" :

```php
        $this->joins[] = [
            'name'    => $name,
            'on'      => $on,
            'columns' => $columns ? $columns : [Select::SQL_STAR],
            'type'    => $type ? $type : Join::JOIN_INNER
        ];
```
This PR  changes the way it's tested, but I would love to get some feedback, especially for the strict equality operator... Looks it worked for me and phpunit but It may not be valid for every use case

```php
        if ($columns === [Select::SQL_STAR] || $columns == Select::SQL_STAR) {
            $columns = [Select::SQL_STAR];
        } elseif (!is_array($columns)) {
            $columns = [$columns];
        }
```

All the best

