### PR TITLE
Fix case sensitivity in ParameterContainer

### DIFF
--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -158,7 +158,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * @param  array $data
      * @return ParameterContainer
      */
-    public function setFromArray(Array $data)
+    public function setFromArray(array $data)
     {
         foreach ($data as $n => $v) {
             $this->offsetSet($n, $v);

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -125,7 +125,7 @@ class Join implements Iterator, Countable
                 sprintf("join() expects '%s' as a single element associative array", array_shift($name))
             );
         }
-        
+
         if ($columns === [Select::SQL_STAR] || $columns == Select::SQL_STAR) {
             $columns = [Select::SQL_STAR];
         } elseif (!is_array($columns)) {
@@ -137,8 +137,8 @@ class Join implements Iterator, Countable
             'on'      => $on,
             'columns' => $columns,
             'type'    => $type ? $type : Join::JOIN_INNER
-        ];        
-        
+        ];
+
         return $this;
     }
 

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -132,10 +132,6 @@ class Join implements Iterator, Countable
             $columns = [$columns];
         }
 
-        if (! is_array($columns)) {
-            $columns = [$columns];
-        }
-        
         $this->joins[] = [
             'name'    => $name,
             'on'      => $on,

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -125,18 +125,24 @@ class Join implements Iterator, Countable
                 sprintf("join() expects '%s' as a single element associative array", array_shift($name))
             );
         }
+        
+        if ($columns === [Select::SQL_STAR] || $columns == Select::SQL_STAR) {
+            $columns = [Select::SQL_STAR];
+        } elseif (!is_array($columns)) {
+            $columns = [$columns];
+        }
 
         if (! is_array($columns)) {
             $columns = [$columns];
         }
-
+        
         $this->joins[] = [
             'name'    => $name,
             'on'      => $on,
-            'columns' => $columns ? $columns : [Select::SQL_STAR],
+            'columns' => $columns,
             'type'    => $type ? $type : Join::JOIN_INNER
-        ];
-
+        ];        
+        
         return $this;
     }
 

--- a/test/Sql/SqlFunctionalTest.php
+++ b/test/Sql/SqlFunctionalTest.php
@@ -101,6 +101,28 @@ class SqlFunctionalTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
+            // Github issue https://github.com/zendframework/zend-db/issues/98
+            'Select::processJoinNoJoinedColumns()' => [
+                'sqlObject' => $this->select('my_table')
+                                    ->join('joined_table2', 'my_table.id = joined_table.id', $columns=[])
+                                    ->columns([
+                                        'my_table_column',
+                                    ]),
+                'expected' => [
+                    'sql92' => [
+                        'string' => 'SELECT "my_table"."my_table_column" AS "my_table_column" FROM "my_table" INNER JOIN "joined_table2" ON "my_table"."id" = "joined_table"."id"',
+                    ],
+                    'MySql' => [
+                        'string' => 'SELECT `my_table`.`my_table_column` AS `my_table_column` FROM `my_table` INNER JOIN `joined_table2` ON `my_table`.`id` = `joined_table`.`id`',
+                    ],
+                    'Oracle' => [
+                        'string' => 'SELECT "my_table"."my_table_column" AS "my_table_column" FROM "my_table" INNER JOIN "joined_table2" ON "my_table"."id" = "joined_table"."id"',
+                    ],
+                    'SqlServer' => [
+                        'string' => 'SELECT [my_table].[my_table_column] AS [my_table_column] FROM [my_table] INNER JOIN [joined_table2] ON [my_table].[id] = [joined_table].[id]',
+                    ]
+                ]
+            ],
             'Select::processJoin()' => [
                 'sqlObject' => $this->select('a')->join(['b'=>$this->select('c')->where(['cc'=>10])], 'd=e')->where(['x'=>20]),
                 'expected'  => [


### PR DESCRIPTION
Fix issue #101 - fix a typoin `Adapter\ParameterContainer::setFromArray(Array $array)` method. Array should be in lowercase.