### PR TITLE
Allow tests to run when no databases are setup

### DIFF
--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -123,7 +123,9 @@ class Connection extends AbstractConnection
         $connection = $this->getConnectionString();
         set_error_handler(function ($number, $string) {
             throw new Exception\RuntimeException(
-                __METHOD__ . ': Unable to connect to database', null, new Exception\ErrorException($string, $number)
+                __METHOD__ . ': Unable to connect to database',
+                null,
+                new Exception\ErrorException($string, $number)
             );
         });
         $this->resource = pg_connect($connection);

--- a/test/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -114,6 +114,9 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($type, self::readAttribute($this->connection, 'type'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetCharset()
     {
         if (! extension_loaded('pgsql')) {
@@ -130,11 +133,18 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'charset'  => 'SQL_ASCII',
         ]);
 
-        $this->connection->connect();
+        try {
+            $this->connection->connect();
+        } catch (AdapterException\RuntimeException $e) {
+            $this->markTestSkipped('Skipping pgsql charset test due to inability to connecto to database');
+        }
 
         $this->assertEquals('SQL_ASCII', pg_client_encoding($this->connection->getResource()));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSetInvalidCharset()
     {
         if (! extension_loaded('pgsql')) {


### PR DESCRIPTION
Prior to 2.7.1, tests ran when:

- ext/pgsql was enabled
- but no databases were setup for pgsql

With the changes introduced to resolve #70, however, the above combination causes cascading failures across the test suite.

Marking the two tests introduced to run in separate processes largely solves the issues. Updating the first test to test for a connection exception prevents a test failure when no database is setup.

Fixes #97.