### PR TITLE
AbstractResultSet implements JsonSerializable

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -13,9 +13,10 @@ use ArrayIterator;
 use Countable;
 use Iterator;
 use IteratorAggregate;
+use JsonSerializable;
 use Zend\Db\Adapter\Driver\ResultInterface;
 
-abstract class AbstractResultSet implements Iterator, ResultSetInterface
+abstract class AbstractResultSet implements Iterator, JsonSerializable, ResultSetInterface
 {
     /**
      * if -1, datasource is already buffered
@@ -276,5 +277,13 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             }
         }
         return $return;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/test/ResultSet/AbstractResultSetTest.php
+++ b/test/ResultSet/AbstractResultSetTest.php
@@ -259,4 +259,25 @@ class AbstractResultSetTest extends \PHPUnit_Framework_TestCase
         $data = $resultSet->current();
         $this->assertEquals(3, $data['id']);
     }
+
+    /**
+     * @covers Zend\Db\ResultSet\AbstractResultSet::jsonSerialize
+     */
+    public function testJsonSerialize()
+    {
+        $resultSet = $this->getMockForAbstractClass('Zend\Db\ResultSet\AbstractResultSet');
+        $resultSet->initialize(new \ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        $this->assertEquals(
+            [
+                ['id' => 1, 'name' => 'one'],
+                ['id' => 2, 'name' => 'two'],
+                ['id' => 3, 'name' => 'three'],
+            ],
+            $resultSet->jsonSerialize()
+        );
+    }
 }


### PR DESCRIPTION
Since the requirements for PHP increased we could benefit from [JsonSerializable](http://php.net/manual/en/jsonserializable.jsonserialize.php).