### PR TITLE
Typo in exception message in AbstractTableGateway

### DIFF
--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -221,7 +221,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
                 && end($selectState['table']) != $this->table)
         ) {
             throw new Exception\RuntimeException(
-                'The table name of the provided select object must match that of the table'
+                'The table name of the provided Select object must match that of the table'
             );
         }
 
@@ -442,7 +442,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $deleteState = $delete->getRawState();
         if ($deleteState['table'] != $this->table) {
             throw new Exception\RuntimeException(
-                'The table name of the provided Update object must match that of the table'
+                'The table name of the provided Delete object must match that of the table'
             );
         }
 


### PR DESCRIPTION
I noticed that a exception message was wrong. I guess someone just copy and pasted but missed to change the text on one spot on row 445 in src/TableGateway/AbstractTableGateway.php

I also changed the exception message for select just to make sure they all look the same with the first letter in uppercase, on line 224 in src/TableGateway/AbstractTableGateway.php