### PR TITLE
Add Adapter\Adapter::class to aliases against AdapterInterface::class

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -35,6 +35,9 @@ class ConfigProvider
             'factories' => [
                 Adapter\AdapterInterface::class => Adapter\AdapterServiceFactory::class,
             ],
+            'aliases' => [
+                Adapter\Adapter::class => Adapter\AdapterInterface::class,
+            ],
         ];
     }
 }


### PR DESCRIPTION
in favor to be used in most existings zf2 app that uses 'Zend\Db\Adapter\Adapter' as service name.