### PR TITLE
TableGateway not using correct default join decleration.

### DIFF
--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -14,6 +14,7 @@ use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\ResultSet\ResultSetInterface;
 use Zend\Db\Sql\Delete;
 use Zend\Db\Sql\Insert;
+use Zend\Db\Sql\Join;
 use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\TableIdentifier;
@@ -340,7 +341,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
         if ($joins) {
             foreach ($joins as $join) {
-                $type = isset($join['type']) ? $join['type'] : $update::JOIN_INNER;
+                $type = isset($join['type']) ? $join['type'] : Join::JOIN_INNER;
                 $update->join($join['name'], $join['on'], $type);
             }
         }

--- a/test/TableGateway/AbstractTableGatewayTest.php
+++ b/test/TableGateway/AbstractTableGatewayTest.php
@@ -281,6 +281,35 @@ class AbstractTableGatewayTest extends \PHPUnit_Framework_TestCase
      * @covers Zend\Db\TableGateway\AbstractTableGateway::updateWith
      * @covers Zend\Db\TableGateway\AbstractTableGateway::executeUpdate
      */
+    public function testUpdateWithJoinDefaultType()
+    {
+        $mockUpdate = $this->mockSql->update();
+
+        $joins = [
+            [
+                'name' => 'baz',
+                'on'   => 'foo.fooId = baz.fooId',
+            ]
+        ];
+
+        // assert select::from() is called
+        $mockUpdate->expects($this->once())
+            ->method('where')
+            ->with($this->equalTo('id = 2'));
+
+        $mockUpdate->expects($this->once())
+            ->method('join')
+            ->with($joins[0]['name'], $joins[0]['on'], Sql\Join::JOIN_INNER);
+
+        $affectedRows = $this->table->update(['foo.field' => 'bar'], 'id = 2', $joins);
+        $this->assertEquals(5, $affectedRows);
+    }
+
+    /**
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::update
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::updateWith
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::executeUpdate
+     */
     public function testUpdateWithNoCriteria()
     {
         $mockUpdate = $this->mockSql->update();


### PR DESCRIPTION
Originaly identified by @Koopzington, tests and implementation by me.