### PR TITLE
Fix up the URLs used in the Coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zend-db
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-db.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-db)
-[![Coverage Status](https://coveralls.io/repos/zendframework/zend-db/badge.svg?branch=master)](https://coveralls.io/r/zendframework/zend-db?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/zendframework/zend-db/badge.svg?branch=master)](https://coveralls.io/github/zendframework/zend-db?branch=master)
 
 `Zend\Db` is a component that abstract the access to a Database using an object
 oriented API to build the queries. `Zend\Db` consumes different storage adapters


### PR DESCRIPTION
[Coveralls](https://coveralls.io/github/zendframework/zend-db) says that it couldn't detect he badge in the Readme. Thought changing the URLs that the badge uses might fix this problem.