### PR TITLE
Removed deprecated src_dir option

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
 coverage_clover: clover.xml
 json_path: coveralls-upload.json
-src_dir: src


### PR DESCRIPTION
That option is deprecated and prevents Coveralls from generating reports.