### PR TITLE
Fix a sequence name with double quotes for PostgreSQL to preserve nam…

### DIFF
--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -117,7 +117,7 @@ class SequenceFeature extends AbstractFeature
                 $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.CURRVAL as "currval" FROM dual';
                 break;
             case 'PostgreSQL':
-                $sql = 'SELECT CURRVAL(\'' . $this->sequenceName . '\')';
+                $sql = 'SELECT CURRVAL(\'"' . $this->sequenceName . '"\')';
                 break;
             default :
                 return;

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -140,7 +140,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         $statementMock = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
         $statementMock->expects($this->any())
             ->method('prepare')
-            ->with('SELECT CURRVAL(\'' . $sequenceName . '\')');
+            ->with('SELECT CURRVAL(\'"' . $sequenceName . '"\')');
         $statementMock->expects($this->any())
             ->method('execute')
             ->will($this->returnValue($resultMock));

--- a/test/TableGateway/Feature/SequenceFeatureTest.php
+++ b/test/TableGateway/Feature/SequenceFeatureTest.php
@@ -71,4 +71,45 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
         return [['PostgreSQL', 'SELECT NEXTVAL(\'"' . $this->sequenceName . '"\')'],
             ['Oracle', 'SELECT ' . $this->sequenceName . '.NEXTVAL as "nextval" FROM dual']];
     }
+
+    /**
+     * @dataProvider lastSequenceIdProvider
+     */
+    public function testLastSequenceId($platformName, $statementSql)
+    {
+        $platform = $this->getMockForAbstractClass('Zend\Db\Adapter\Platform\PlatformInterface', ['getName']);
+        $platform->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($platformName));
+        $platform->expects($this->any())
+            ->method('quoteIdentifier')
+            ->will($this->returnValue($this->sequenceName));
+        $adapter = $this->getMock('Zend\Db\Adapter\Adapter', ['getPlatform', 'createStatement'], [], '', false);
+        $adapter->expects($this->any())
+            ->method('getPlatform')
+            ->will($this->returnValue($platform));
+        $result = $this->getMockForAbstractClass('Zend\Db\Adapter\Driver\ResultInterface', [], '', false, true, true, ['current']);
+        $result->expects($this->any())
+            ->method('current')
+            ->will($this->returnValue(['currval' => 1]));
+        $statement = $this->getMockForAbstractClass('Zend\Db\Adapter\Driver\StatementInterface', [], '', false, true, true, ['prepare', 'execute']);
+        $statement->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue($result));
+        $statement->expects($this->any())
+            ->method('prepare')
+            ->with($statementSql);
+        $adapter->expects($this->once())
+            ->method('createStatement')
+            ->will($this->returnValue($statement));
+        $this->tableGateway = $this->getMockForAbstractClass('Zend\Db\TableGateway\TableGateway', ['table', $adapter], '', true);
+        $this->feature->setTableGateway($this->tableGateway);
+        $this->feature->lastSequenceId();
+    }
+
+    public function lastSequenceIdProvider()
+    {
+        return [['PostgreSQL', 'SELECT CURRVAL(\'"' . $this->sequenceName . '"\')'],
+            ['Oracle', 'SELECT ' . $this->sequenceName . '.CURRVAL as "currval" FROM dual']];
+    }
 }


### PR DESCRIPTION
…e registry when try to get last sequence id
See description for bug (https://github.com/zendframework/zendframework/pull/6222)
