### PR TITLE
SequenceFeature doesn't set lastInsertValue correctly before the inse…

### DIFF
--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -47,6 +47,8 @@ class SequenceFeature extends AbstractFeature
      */
     public function preInsert(Insert $insert)
     {
+        $this->tableGateway->lastInsertValue = $this->lastSequenceId();
+
         $columns = $insert->getRawState('columns');
         $values = $insert->getRawState('values');
         $key = array_search($this->primaryKeyField, $columns);
@@ -70,9 +72,7 @@ class SequenceFeature extends AbstractFeature
      */
     public function postInsert(StatementInterface $statement, ResultInterface $result)
     {
-        if ($this->sequenceValue !== null) {
-            $this->tableGateway->lastInsertValue = $this->sequenceValue;
-        }
+        $this->tableGateway->lastInsertValue = $this->sequenceValue;
     }
 
     /**

--- a/test/TableGateway/Feature/SequenceFeatureTest.php
+++ b/test/TableGateway/Feature/SequenceFeatureTest.php
@@ -66,9 +66,58 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
         $this->feature->nextSequenceId();
     }
 
+    /**
+     * @dataProvider lastSequenceIdProvider
+     */
+    public function testPreInsertWillReturnLastInsertValueIfPrimaryKeySetInColumnsData($platformName, $statementSql)
+    {
+        $platform = $this->getMockForAbstractClass('Zend\Db\Adapter\Platform\PlatformInterface', ['getName']);
+        $platform->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($platformName));
+        $platform->expects($this->any())
+            ->method('quoteIdentifier')
+            ->will($this->returnValue($this->sequenceName));
+        $adapter = $this->getMock('Zend\Db\Adapter\Adapter', ['getPlatform', 'createStatement'], [], '', false);
+        $adapter->expects($this->any())
+            ->method('getPlatform')
+            ->will($this->returnValue($platform));
+        $result = $this->getMockForAbstractClass('Zend\Db\Adapter\Driver\ResultInterface', [], '', false, true, true,
+            ['current']);
+        $result->expects($this->any())
+            ->method('current')
+            ->will($this->returnValue(['currval' => 1]));
+        $statement = $this->getMockForAbstractClass('Zend\Db\Adapter\Driver\StatementInterface', [], '', false, true, true, ['prepare', 'execute']);
+        $statement->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue($result));
+        $statement->expects($this->any())
+            ->method('prepare')
+            ->with($statementSql);
+        $adapter->expects($this->any())
+            ->method('createStatement')
+            ->will($this->returnValue($statement));
+        $this->tableGateway = $this->getMockForAbstractClass('Zend\Db\TableGateway\TableGateway', ['table', $adapter], '', true);
+        $this->feature->setTableGateway($this->tableGateway);
+        $insert = $this->getMock('Zend\Db\Sql\Insert', ['getPlatform', 'createStatement', 'getRawState'], [], '', false);
+        $insert->expects($this->at(0))
+            ->method('getRawState')
+            ->with('columns')
+            ->will($this->returnValue(['id']));
+        /** @var \Zend\Db\Sql\Insert $insert */
+        $this->feature->preInsert($insert);
+        $this->assertEquals(1, $this->tableGateway->getLastInsertValue());
+    }
+
     public function nextSequenceIdProvider()
     {
         return [['PostgreSQL', 'SELECT NEXTVAL(\'"' . $this->sequenceName . '"\')'],
             ['Oracle', 'SELECT ' . $this->sequenceName . '.NEXTVAL as "nextval" FROM dual']];
+    }
+
+    public function lastSequenceIdProvider()
+    {
+        return [['PostgreSQL', 'SELECT CURRVAL(\'' . $this->sequenceName . '\')'],
+            ['Oracle', 'SELECT ' . $this->sequenceName . '.CURRVAL as "currval" FROM dual']];
     }
 }


### PR DESCRIPTION
…rt was done
Fix for this issue: [#142](https://github.com/zendframework/zend-db/issues/142)
it is always +1 higher becouse lastInsertValue set from nextSequenceId()
