### PR TITLE
SQLite $select->combine() support

### DIFF
--- a/src/Sql/Platform/Platform.php
+++ b/src/Sql/Platform/Platform.php
@@ -36,11 +36,13 @@ class Platform extends AbstractPlatform
         $sqlServerPlatform = new SqlServer\SqlServer();
         $oraclePlatform    = new Oracle\Oracle();
         $ibmDb2Platform    = new IbmDb2\IbmDb2();
+        $sqlitePlatform    = new Sqlite\Sqlite();
 
         $this->decorators['mysql']     = $mySqlPlatform->getDecorators();
         $this->decorators['sqlserver'] = $sqlServerPlatform->getDecorators();
         $this->decorators['oracle']    = $oraclePlatform->getDecorators();
         $this->decorators['ibmdb2']    = $ibmDb2Platform->getDecorators();
+        $this->decorators['sqlite']    = $sqlitePlatform->getDecorators();
     }
 
     /**

--- a/src/Sql/Platform/Sqlite/SelectDecorator.php
+++ b/src/Sql/Platform/Sqlite/SelectDecorator.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Sqlite;
+
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\PlatformInterface;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Sql\Select;
+
+class SelectDecorator extends Select implements PlatformDecoratorInterface
+{
+    /**
+     * @var Select
+     */
+    protected $subject = null;
+
+    /**
+     * @param Select $select
+     */
+    public function setSubject($select)
+    {
+        $this->subject = $select;
+    }
+
+    protected function localizeVariables()
+    {
+        parent::localizeVariables();
+        $this->specifications[self::COMBINE] = '%1$s %2$s';
+    }
+
+    protected function processStatementStart(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    {
+        return '';
+    }
+
+    protected function processStatementEnd(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    {
+        return '';
+    }
+}

--- a/src/Sql/Platform/Sqlite/SelectDecorator.php
+++ b/src/Sql/Platform/Sqlite/SelectDecorator.php
@@ -23,24 +23,38 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     protected $subject = null;
 
     /**
+     * Set Subject
+     *
      * @param Select $select
+     * @return self
      */
     public function setSubject($select)
     {
         $this->subject = $select;
+
+        return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function localizeVariables()
     {
         parent::localizeVariables();
         $this->specifications[self::COMBINE] = '%1$s %2$s';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function processStatementStart(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         return '';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function processStatementEnd(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         return '';

--- a/src/Sql/Platform/Sqlite/Sqlite.php
+++ b/src/Sql/Platform/Sqlite/Sqlite.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Sqlite;
+
+use Zend\Db\Sql\Platform\AbstractPlatform;
+
+class Sqlite extends AbstractPlatform
+{
+    public function __construct()
+    {
+        $this->setTypeDecorator('Zend\Db\Sql\Select', new SelectDecorator());
+    }
+}

--- a/src/Sql/Platform/Sqlite/Sqlite.php
+++ b/src/Sql/Platform/Sqlite/Sqlite.php
@@ -13,6 +13,11 @@ use Zend\Db\Sql\Platform\AbstractPlatform;
 
 class Sqlite extends AbstractPlatform
 {
+    /**
+     * Constructor
+     *
+     * Registers the type decorator.
+     */
     public function __construct()
     {
         $this->setTypeDecorator('Zend\Db\Sql\Select', new SelectDecorator());

--- a/test/Sql/Platform/Sqlite/SelectDecoratorTest.php
+++ b/test/Sql/Platform/Sqlite/SelectDecoratorTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform\Sqlite;
+
+use Zend\Db\Sql\Platform\Sqlite\SelectDecorator;
+use Zend\Db\Sql\Select;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\Sqlite as SqlitePlatform;
+
+class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper limit/offset sql statement
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::prepareStatement
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processLimit
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processOffset
+     * @dataProvider dataProvider
+     */
+    public function testPrepareStatement(Select $select, $expectedSql, $expectedParams)
+    {
+        $driver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $driver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+
+        // test
+        $adapter = $this->getMock(
+            'Zend\Db\Adapter\Adapter',
+            null,
+            [
+                $driver,
+                new SqlitePlatform()
+            ]
+        );
+
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $statement->expects($this->once())->method('setSql')->with($expectedSql);
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $selectDecorator->prepareStatement($adapter, $statement);
+
+        $this->assertEquals($expectedParams, $parameterContainer->getNamedArray());
+    }
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper limit/offset sql statement
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::getSqlString
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processLimit
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processOffset
+     * @dataProvider dataProvider
+     */
+    public function testGetSqlString(Select $select, $ignore, $alsoIgnore, $expectedSql)
+    {
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $this->assertEquals($expectedSql, $selectDecorator->getSqlString(new SqlitePlatform));
+    }
+
+    public function dataProvider()
+    {
+        $select0 = new Select;
+        $select0->from('foo');
+        $select1 = clone $select0;
+        $select0->combine($select1);
+
+        $expectedPrepareSql0 = ' SELECT "foo".* FROM "foo"  UNION  SELECT "foo".* FROM "foo"';
+        $expectedParams0 = [];
+        $expectedSql0 = ' SELECT "foo".* FROM "foo"  UNION  SELECT "foo".* FROM "foo"';
+
+        return [
+            [$select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0],
+        ];
+    }
+}

--- a/test/Sql/Platform/Sqlite/SelectDecoratorTest.php
+++ b/test/Sql/Platform/Sqlite/SelectDecoratorTest.php
@@ -17,13 +17,13 @@ use Zend\Db\Adapter\Platform\Sqlite as SqlitePlatform;
 class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper limit/offset sql statement
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper combine
+     * statement
      * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::prepareStatement
-     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processLimit
-     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processOffset
-     * @dataProvider dataProvider
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processCombine
+     * @dataProvider dataProviderUnionSyntaxFromCombine
      */
-    public function testPrepareStatement(Select $select, $expectedSql, $expectedParams)
+    public function testPrepareStatementPreparesUnionSyntaxFromCombine(Select $select, $expectedSql, $expectedParams)
     {
         $driver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $driver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
@@ -52,13 +52,13 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper limit/offset sql statement
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper combine
+     * statement
      * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::getSqlString
-     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processLimit
-     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processOffset
-     * @dataProvider dataProvider
+     * @covers Zend\Db\Sql\Platform\Sqlite\SelectDecorator::processCombine
+     * @dataProvider dataProviderUnionSyntaxFromCombine
      */
-    public function testGetSqlString(Select $select, $ignore, $alsoIgnore, $expectedSql)
+    public function testGetSqlStringPreparesUnionSyntaxFromCombine(Select $select, $ignore, $alsoIgnore, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
@@ -69,7 +69,12 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedSql, $selectDecorator->getSqlString(new SqlitePlatform));
     }
 
-    public function dataProvider()
+    /**
+     * Create a data provider for union syntax that would come from combine
+     *
+     * @return mixed[]
+     */
+    public function dataProviderUnionSyntaxFromCombine()
     {
         $select0 = new Select;
         $select0->from('foo');

--- a/test/Sql/Platform/Sqlite/SqliteTest.php
+++ b/test/Sql/Platform/Sqlite/SqliteTest.php
@@ -14,10 +14,10 @@ use Zend\Db\Sql\Platform\Sqlite\Sqlite;
 class SqliteTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @testdox unit test / object test: Test Sqlite object has Select proxy
+     * @testdox unit test / object test: Test Sqlite constructor will register the decorator
      * @covers Zend\Db\Sql\Platform\Sqlite\Sqlite::__construct
      */
-    public function testConstruct()
+    public function testConstructorRegistersSqliteDecorator()
     {
         $mysql = new Sqlite;
         $decorators = $mysql->getDecorators();

--- a/test/Sql/Platform/Sqlite/SqliteTest.php
+++ b/test/Sql/Platform/Sqlite/SqliteTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform\Sqlite;
+
+use Zend\Db\Sql\Platform\Sqlite\Sqlite;
+
+class SqliteTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox unit test / object test: Test Sqlite object has Select proxy
+     * @covers Zend\Db\Sql\Platform\Sqlite\Sqlite::__construct
+     */
+    public function testConstruct()
+    {
+        $mysql = new Sqlite;
+        $decorators = $mysql->getDecorators();
+
+        list($type, $decorator) = each($decorators);
+        $this->assertEquals('Zend\Db\Sql\Select', $type);
+        $this->assertInstanceOf('Zend\Db\Sql\Platform\Sqlite\SelectDecorator', $decorator);
+    }
+}


### PR DESCRIPTION
SQLite does not allow parentheses in a union.  You can find this in the
documentation on SQLite located at:
https://www.sqlite.org/lang_select.html as a secondary, you may look to
a tutorial on unions in SQLite at:
http://www.sqlitetutorial.net/sqlite-union/

This resolves issue #75 - SQLite error on UNION.