### PR TITLE
Alter docs about Select and TableIdentifier usage

### DIFF
--- a/doc/book/sql.md
+++ b/doc/book/sql.md
@@ -150,7 +150,7 @@ $select->from(['t' => 'table']);
 
 // Using a Sql\TableIdentifier:
 // (same output as above)
-$select->from(new TableIdentifier(['t' => 'table']));
+$select->from(['t' => new TableIdentifier('table')]);
 ```
 
 ### columns()


### PR DESCRIPTION
There's a typo in TableIdentifier usage in Select `from` method with alias.
