### PR TITLE
DDL with TableIdentifier

### DIFF
--- a/doc/book/sql-ddl.md
+++ b/doc/book/sql-ddl.md
@@ -20,11 +20,15 @@ the same for `ALTER TABLE` (as `AlterTable`), and `DROP TABLE` (as
 
 ```php
 use Zend\Db\Sql\Ddl;
+use Zend\Db\Sql\TableIdentifier;
 
 $table = new Ddl\CreateTable();
 
 // With a table name:
 $table = new Ddl\CreateTable('bar');
+
+// With a schema name "foo":
+$table = new Ddl\CreateTable(new TableIdentifier('bar', 'foo'));
 
 // Optionally, as a temporary table:
 $table = new Ddl\CreateTable('bar', true);
@@ -63,11 +67,15 @@ Similar to `CreateTable`, you may also use `AlterTable` instances:
 
 ```php
 use Zend\Db\Sql\Ddl;
+use Zend\Db\Sql\TableIdentifier;
 
 $table = new Ddl\AlterTable();
 
 // With a table name:
 $table = new Ddl\AlterTable('bar');
+
+// With a schema name "foo":
+$table = new Ddl\AlterTable(new TableIdentifier('bar', 'foo'));
 
 // Optionally, as a temporary table:
 $table = new Ddl\AlterTable('bar', true);
@@ -97,9 +105,13 @@ To drop a table, create a `DropTable` instance:
 
 ```php
 use Zend\Db\Sql\Ddl;
+use Zend\Db\Sql\TableIdentifier;
 
 // With a table name:
 $drop = new Ddl\DropTable('bar');
+
+// With a schema name "foo":
+$drop = new Ddl\DropTable(new TableIdentifier('bar', 'foo'));
 ```
 
 ## Executing DDL Statements

--- a/doc/book/sql-ddl.md
+++ b/doc/book/sql-ddl.md
@@ -96,6 +96,9 @@ $table->dropConstraint('my_index');
 To drop a table, create a `DropTable` instance:
 
 ```php
+use Zend\Db\Sql\Ddl;
+
+// With a table name:
 $drop = new Ddl\DropTable('bar');
 ```
 

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -179,7 +179,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     protected function processTable(PlatformInterface $adapterPlatform = null)
     {
-        return [$adapterPlatform->quoteIdentifier($this->table)];
+        return [$this->resolveTable($this->table, $adapterPlatform)];
     }
 
     protected function processAddColumns(PlatformInterface $adapterPlatform = null)

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -139,7 +139,7 @@ class CreateTable extends AbstractSql implements SqlInterface
     {
         return [
             $this->isTemporary ? 'TEMPORARY ' : '',
-            $adapterPlatform->quoteIdentifier($this->table),
+            $this->resolveTable($this->table, $adapterPlatform),
         ];
     }
 

--- a/src/Sql/Ddl/DropTable.php
+++ b/src/Sql/Ddl/DropTable.php
@@ -38,6 +38,6 @@ class DropTable extends AbstractSql implements SqlInterface
 
     protected function processTable(PlatformInterface $adapterPlatform = null)
     {
-        return [$adapterPlatform->quoteIdentifier($this->table)];
+        return [$this->resolveTable($this->table, $adapterPlatform)];
     }
 }

--- a/test/Sql/Ddl/AlterTableTest.php
+++ b/test/Sql/Ddl/AlterTableTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Db\Sql\Ddl;
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column;
 use Zend\Db\Sql\Ddl\Constraint;
+use Zend\Db\Sql\TableIdentifier;
 
 class AlterTableTest extends \PHPUnit_Framework_TestCase
 {
@@ -108,5 +109,13 @@ EOS;
             str_replace(["\r", "\n"], "", $expected),
             str_replace(["\r", "\n"], "", $actual)
         );
+
+        $at = new AlterTable(new TableIdentifier('foo'));
+        $at->addColumn(new Column\Column('bar'));
+        $this->assertEquals("ALTER TABLE \"foo\"\n ADD COLUMN \"bar\" INTEGER NOT NULL", $at->getSqlString());
+
+        $at = new AlterTable(new TableIdentifier('bar', 'foo'));
+        $at->addColumn(new Column\Column('baz'));
+        $this->assertEquals("ALTER TABLE \"foo\".\"bar\"\n ADD COLUMN \"baz\" INTEGER NOT NULL", $at->getSqlString());
     }
 }

--- a/test/Sql/Ddl/CreateTableTest.php
+++ b/test/Sql/Ddl/CreateTableTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Db\Sql\Ddl;
 use Zend\Db\Sql\Ddl\Column\Column;
 use Zend\Db\Sql\Ddl\Constraint;
 use Zend\Db\Sql\Ddl\CreateTable;
+use Zend\Db\Sql\TableIdentifier;
 
 class CreateTableTest extends \PHPUnit_Framework_TestCase
 {
@@ -152,5 +153,13 @@ class CreateTableTest extends \PHPUnit_Framework_TestCase
         $ct->addConstraint(new Constraint\PrimaryKey('bar'));
         $ct->addConstraint(new Constraint\PrimaryKey('bat'));
         $this->assertEquals("CREATE TABLE \"foo\" ( \n    PRIMARY KEY (\"bar\"),\n    PRIMARY KEY (\"bat\") \n)", $ct->getSqlString());
+
+        $ct = new CreateTable(new TableIdentifier('foo'));
+        $ct->addColumn(new Column('bar'));
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ct->getSqlString());
+
+        $ct = new CreateTable(new TableIdentifier('bar', 'foo'));
+        $ct->addColumn(new Column('baz'));
+        $this->assertEquals("CREATE TABLE \"foo\".\"bar\" ( \n    \"baz\" INTEGER NOT NULL \n)", $ct->getSqlString());
     }
 }

--- a/test/Sql/Ddl/DropTableTest.php
+++ b/test/Sql/Ddl/DropTableTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Db\Sql\Ddl;
 
 use Zend\Db\Sql\Ddl\DropTable;
+use Zend\Db\Sql\TableIdentifier;
 
 class DropTableTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,5 +21,11 @@ class DropTableTest extends \PHPUnit_Framework_TestCase
     {
         $dt = new DropTable('foo');
         $this->assertEquals('DROP TABLE "foo"', $dt->getSqlString());
+
+        $dt = new DropTable(new TableIdentifier('foo'));
+        $this->assertEquals('DROP TABLE "foo"', $dt->getSqlString());
+
+        $dt = new DropTable(new TableIdentifier('bar', 'foo'));
+        $this->assertEquals('DROP TABLE "foo"."bar"', $dt->getSqlString());
     }
 }


### PR DESCRIPTION
Enables usage of TableIdentifier in CreateTable, AlterTable and DropTable DDLs.
