### PR TITLE
Postgresql indexes

### DIFF
--- a/src/Sql/Ddl/Index/Index.php
+++ b/src/Sql/Ddl/Index/Index.php
@@ -26,7 +26,7 @@ class Index extends AbstractIndex
      * @param  null|string $name
      * @param array $lengths
      */
-    public function __construct($columns, $name = null, array $lengths = [])
+    public function __construct($columns = null, $name = null, array $lengths = [])
     {
         $this->setColumns($columns);
 

--- a/src/Sql/Platform/Platform.php
+++ b/src/Sql/Platform/Platform.php
@@ -13,6 +13,7 @@ use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Sql\Exception;
+use Zend\Db\Sql\Platform\Postgresql;
 use Zend\Db\Sql\PreparableSqlInterface;
 use Zend\Db\Sql\SqlInterface;
 
@@ -32,17 +33,19 @@ class Platform extends AbstractPlatform
     {
         $this->defaultPlatform = $adapter->getPlatform();
 
-        $mySqlPlatform     = new Mysql\Mysql();
-        $sqlServerPlatform = new SqlServer\SqlServer();
-        $oraclePlatform    = new Oracle\Oracle();
-        $ibmDb2Platform    = new IbmDb2\IbmDb2();
-        $sqlitePlatform    = new Sqlite\Sqlite();
+        $mySqlPlatform      = new Mysql\Mysql();
+        $sqlServerPlatform  = new SqlServer\SqlServer();
+        $oraclePlatform     = new Oracle\Oracle();
+        $ibmDb2Platform     = new IbmDb2\IbmDb2();
+        $sqlitePlatform     = new Sqlite\Sqlite();
+        $postgresqlPlatform = new Postgresql\Postgresql();
 
-        $this->decorators['mysql']     = $mySqlPlatform->getDecorators();
-        $this->decorators['sqlserver'] = $sqlServerPlatform->getDecorators();
-        $this->decorators['oracle']    = $oraclePlatform->getDecorators();
-        $this->decorators['ibmdb2']    = $ibmDb2Platform->getDecorators();
-        $this->decorators['sqlite']    = $sqlitePlatform->getDecorators();
+        $this->decorators['mysql']      = $mySqlPlatform->getDecorators();
+        $this->decorators['sqlserver']  = $sqlServerPlatform->getDecorators();
+        $this->decorators['oracle']     = $oraclePlatform->getDecorators();
+        $this->decorators['ibmdb2']     = $ibmDb2Platform->getDecorators();
+        $this->decorators['sqlite']     = $sqlitePlatform->getDecorators();
+        $this->decorators['postgresql'] = $postgresqlPlatform->getDecorators();
     }
 
     /**

--- a/src/Sql/Platform/Postgresql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/AlterTableDecorator.php
@@ -1,22 +1,138 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
 
 namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
 
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl\Index\Index;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Sql\Platform\Postgresql\Ddl\Index\IndexDecorator;
 
 class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterface
 {
+    const ADD_INDEXES = 'addIndexes';
+
     /**
      * @var AlterTable
      */
-    private $subject;
+    protected $subject;
+
+    /**
+     * @var IndexDecorator[]
+     */
+    protected $addIndexes = [];
+
+    /**
+     * @var bool
+     */
+    private $hasCreateTable = true;
+
+    protected $indexSpecification = [
+        'statementEnd' => '%1$s',
+        self::ADD_INDEXES => [
+            "%1\$s" => [
+                [1 => '%1$s;', 'combinedby' => "\n"]
+            ]
+        ],
+    ];
 
     /**
      * @inheritDoc
      */
     public function setSubject($subject) {
         $this->subject = $subject;
+
+        return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
+    protected function buildSqlString(
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null
+    ) {
+        $this->separateIndexesFromConstraints();
+        $this->deleteUnneededSpecification();
+
+        $alterTable = '';
+        if ($this->hasCreateTable) {
+            $alterTable = parent::buildSqlString($platform, $driver, $parameterContainer);
+            $this->subject->specifications = $this->specifications = $this->indexSpecification;
+        }
+
+        $indexes = parent::buildSqlString($platform, $driver, $parameterContainer);
+        return $alterTable.$indexes;
+    }
+
+    private function separateIndexesFromConstraints()
+    {
+        // take advantage of PHP's ability to access protected properties of different instances created from same class
+        $this->addIndexes = array_filter($this->subject->addConstraints, function($constraint) {
+            return $constraint instanceof Index;
+        });
+
+        $filteredConstraints = array_filter($this->subject->addConstraints, function($constraint) {
+            return !($constraint instanceof Index);
+        });
+
+        $this->subject->addConstraints = $filteredConstraints;
+
+        array_walk($this->addIndexes, function (&$index, $key) {
+            $indexDecorator = new IndexDecorator();
+            $indexDecorator->setSubject($index);
+            $indexDecorator->setTable($this->subject->table);
+            $index = $indexDecorator;
+        });
+    }
+
+    /**
+     * @param PlatformInterface|null $adapterPlatform
+     * @return array|void
+     */
+    protected function processAddIndexes(PlatformInterface $adapterPlatform = null) {
+        if (!$this->addIndexes) {
+            return;
+        }
+
+        $sqls = [];
+
+        foreach ($this->addIndexes as $index) {
+            $sqls[] = $this->processExpression($index, $adapterPlatform);
+        }
+
+        return [$sqls];
+    }
+
+    /**
+     * @param PlatformInterface|null $adapterPlatform
+     * @return array|void
+     */
+    protected function processStatementEnd(PlatformInterface $adapterPlatform = null)
+    {
+        return [";\n"];
+    }
+
+    private function deleteUnneededSpecification()
+    {
+        $subject = $this->subject;
+        if (!($subject->addColumns || $subject->changeColumns || $subject->dropColumns
+            || $subject->addConstraints || $subject->dropConstraints)) {
+
+            $this->hasCreateTable = false;
+
+            unset($this->indexSpecification['statementEnd']);
+            $this->subject->specifications = $this->specifications = $this->indexSpecification;
+        }
+    }
 }

--- a/src/Sql/Platform/Postgresql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/AlterTableDecorator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
+
+use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+
+class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterface
+{
+    /**
+     * @var AlterTable
+     */
+    private $subject;
+
+    /**
+     * @inheritDoc
+     */
+    public function setSubject($subject) {
+        $this->subject = $subject;
+    }
+
+}

--- a/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
@@ -27,7 +27,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     protected $subject;
 
     /**
-     * @var string[]
+     * @var IndexDecorator[]
      */
     protected $indexes = [];
 

--- a/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
+
+use Zend\Db\Sql\Ddl\CreateTable;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Adapter\Platform\PlatformInterface;
+
+class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
+{
+
+    /**
+     * @var CreateTable
+     */
+    protected $subject;
+
+    /**
+     * @inheritDoc
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    protected function processStatementEnd(PlatformInterface $adapterPlatform = null)
+    {
+        return ["\n);"];
+    }
+
+}

--- a/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/CreateTableDecorator.php
@@ -9,12 +9,17 @@
 
 namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
 
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Sql\Ddl\CreateTable;
+use Zend\Db\Sql\Ddl\Index\Index;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Adapter\Platform\PlatformInterface;
+use Zend\Db\Sql\Platform\Postgresql\Ddl\Index\IndexDecorator;
 
 class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
 {
+    const INDEXES = 'indexes';
 
     /**
      * @var CreateTable
@@ -22,13 +27,90 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     protected $subject;
 
     /**
+     * @var string[]
+     */
+    protected $indexes = [];
+
+    /**
      * @inheritDoc
      */
-    public function setSubject($subject)
-    {
+    protected $indexSpecification = [
+        self::INDEXES => [
+            "\n%1\$s" => [
+                [1 => '%1$s;', 'combinedby' => "\n"]
+            ]
+        ]
+    ];
+
+    /**
+     * @param $subject
+     * @return mixed
+     */
+    public function setSubject($subject) {
         $this->subject = $subject;
+
+        $this->specifications = array_merge($this->specifications, $this->indexSpecification);
+        $this->subject->specifications = $this->specifications;
+
+        return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
+    protected function buildSqlString(
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null
+    ) {
+        $this->separateIndexesFromConstraints();
+
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
+    }
+
+    private function separateIndexesFromConstraints()
+    {
+        // take advantage of PHP's ability to access protected properties of different instances created from same class
+        $this->indexes = array_filter($this->subject->constraints, function($constraint) {
+            return $constraint instanceof Index;
+        });
+
+        $filteredConstraints = array_filter($this->subject->constraints, function($constraint) {
+            return !($constraint instanceof Index);
+        });
+
+        $this->subject->constraints = $filteredConstraints;
+
+        array_walk($this->indexes, function (&$index, $key) {
+            $indexDecorator = new IndexDecorator();
+            $indexDecorator->setSubject($index);
+            $indexDecorator->setTable($this->subject->table);
+            $index = $indexDecorator;
+        });
+    }
+
+    /**
+     * @param PlatformInterface|null $adapterPlatform
+     * @return array|void
+     */
+    protected function processIndexes(PlatformInterface $adapterPlatform = null) {
+        if (!$this->indexes) {
+            return;
+        }
+
+        $sqls = [];
+
+        foreach ($this->indexes as $index) {
+            $sqls[] = $this->processExpression($index, $adapterPlatform);
+        }
+
+        return [$sqls];
+    }
+
+    /**
+     * @param PlatformInterface|null $adapterPlatform
+     * @return array|void
+     */
     protected function processStatementEnd(PlatformInterface $adapterPlatform = null)
     {
         return ["\n);"];

--- a/src/Sql/Platform/Postgresql/Ddl/Index/IndexDecorator.php
+++ b/src/Sql/Platform/Postgresql/Ddl/Index/IndexDecorator.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl\Index;
+
+use Zend\Db\Adapter\Exception\InvalidQueryException;
+use Zend\Db\Sql\Ddl\Index\Index;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+
+class IndexDecorator extends Index implements PlatformDecoratorInterface
+{
+
+    /**
+     * @var Index
+     */
+    protected $subject = null;
+
+    protected $specification = 'CREATE INDEX %s ON %s(...)';
+
+    private $table;
+
+    /**
+     * @inheritDoc
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        $this->subject->specification = $this->specification;
+    }
+
+    public function setTable($table)
+    {
+        $this->table = $table;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getExpressionData()
+    {
+        if (!$this->table) {
+            throw new InvalidQueryException('PostgreSQL Index needs table name specified.');
+        }
+
+        $expressionData = $this->subject->getExpressionData();
+
+        // [0] => specification
+        // [1] => values
+        // [2] => types
+        array_splice($expressionData[0][1], 1, 0, $this->table);
+        array_splice($expressionData[0][2], 1, 0, self::TYPE_IDENTIFIER);
+
+        return $expressionData;
+    }
+}

--- a/src/Sql/Platform/Postgresql/Postgresql.php
+++ b/src/Sql/Platform/Postgresql/Postgresql.php
@@ -15,6 +15,6 @@ class Postgresql extends AbstractPlatform
 {
     public function __construct()
     {
-
+        $this->setTypeDecorator('Zend\Db\Sql\Ddl\CreateTable', new Ddl\CreateTableDecorator());
     }
 }

--- a/src/Sql/Platform/Postgresql/Postgresql.php
+++ b/src/Sql/Platform/Postgresql/Postgresql.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql;
+
+use Zend\Db\Sql\Platform\AbstractPlatform;
+
+class Postgresql extends AbstractPlatform
+{
+    public function __construct()
+    {
+
+    }
+}

--- a/src/Sql/Platform/Postgresql/Postgresql.php
+++ b/src/Sql/Platform/Postgresql/Postgresql.php
@@ -16,5 +16,6 @@ class Postgresql extends AbstractPlatform
     public function __construct()
     {
         $this->setTypeDecorator('Zend\Db\Sql\Ddl\CreateTable', new Ddl\CreateTableDecorator());
+        $this->setTypeDecorator('Zend\Db\Sql\Ddl\AlterTable', new Ddl\AlterTableDecorator());
     }
 }

--- a/test/Sql/Platform/PlatformTest.php
+++ b/test/Sql/Platform/PlatformTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Db\Sql\Platform;
 
 use ReflectionMethod;
 use Zend\Db\Adapter\StatementContainer;
+use Zend\Db\Sql\Platform\Postgresql\Postgresql;
 use ZendTest\Db\TestAsset;
 use Zend\Db\Sql\Platform\Platform;
 use Zend\Db\Adapter\Adapter;
@@ -41,6 +42,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sqlserver', $reflectionMethod->invoke($platform, new TestAsset\TrustingSqlServerPlatform()));
         $this->assertEquals('oracle', $reflectionMethod->invoke($platform, new TestAsset\TrustingOraclePlatform()));
         $this->assertEquals('sql92', $reflectionMethod->invoke($platform, new TestAsset\TrustingSql92Platform()));
+        $this->assertEquals('postgresql', $reflectionMethod->invoke($platform, new TestAsset\TrustingPostgresqlPlatform()));
     }
 
     /**
@@ -84,6 +86,17 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider availablePlatformDecorators
+     */
+    public function testDecoratorsRegistered($adapter, $decorators)
+    {
+        $platform = new Platform($adapter);
+        $registeredDecorators = $platform->getDecorators();
+
+        $this->assertEquals($registeredDecorators, $decorators);
+    }
+
+    /**
      * @param string $platformName
      *
      * @return Adapter
@@ -105,6 +118,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
             case 'SqlServer' :
                 $platform = new TestAsset\TrustingSqlServerPlatform();
                 break;
+            case 'PostgreSQL' :
+                $platform = new TestAsset\TrustingPostgresqlPlatform();
         }
 
         /* @var $mockDriver \Zend\Db\Adapter\Driver\DriverInterface|\PHPUnit_Framework_MockObject_MockObject */
@@ -116,5 +131,13 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         }));
 
         return new Adapter($mockDriver, $platform);
+    }
+
+    public function availablePlatformDecorators()
+    {
+        return [
+            //@TODO add all supported platforms
+            [$this->resolveAdapter('PostgreSQL'), (new Postgresql())->getDecorators()],
+        ];
     }
 }

--- a/test/Sql/Platform/Postgresql/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/AlterTableDecoratorTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
+
+use Zend\Db\Adapter\Platform\Postgresql;
+use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl;
+use Zend\Db\Sql\Platform\Postgresql\Ddl\AlterTableDecorator;
+
+class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @dataProvider tableAlterationsProvider
+     */
+    public function testGetSqlString(AlterTable $createTable, $expectedSql)
+    {
+        $alterTableDecorator = new AlterTableDecorator();
+        $alterTableDecorator->setSubject($createTable);
+
+        $adapterPlatform = new Postgresql();
+        $createTableSql = $alterTableDecorator->getSqlString($adapterPlatform);
+        $this->assertEquals($expectedSql, $createTableSql);
+    }
+
+    public function tableAlterationsProvider()
+    {
+        $newIdx = new Ddl\Index\Index('field_1', 'new_idx');
+        $newField_2 = new Ddl\Column\Varchar('field_2');
+        $newField_2->setLength(1024);
+
+        // AlterTable on its own
+        $noIndex = new Ddl\AlterTable('no_index');
+        $noIndex->addColumn($newField_2);
+
+        // AlterTable on its own
+        $onlyIndex = new Ddl\AlterTable('only_index');
+        $onlyIndex->addConstraint($newIdx);
+
+        // AlterTable with Create Index
+        $mixedAddIndex = new Ddl\AlterTable('mixed_index');
+        $mixedAddIndex->addColumn($newField_2);
+        $mixedAddIndex->addConstraint($newIdx);
+
+        $expectedNewFieldNoIndex = 'ALTER TABLE "no_index"' . "\n"
+                                 . ' ADD COLUMN "field_2" VARCHAR(1024) NOT NULL;';
+
+        $expectedOnlyIndex = 'CREATE INDEX "new_idx" ON "only_index"("field_1");';
+
+        $expectedMixedAddIndex = 'ALTER TABLE "mixed_index"' . "\n"
+                               . ' ADD COLUMN "field_2" VARCHAR(1024) NOT NULL;' . "\n"
+                               . ' CREATE INDEX "new_idx" ON "mixed_index"("field_1");';
+
+        return [
+            [$noIndex,          $expectedNewFieldNoIndex],
+            [$onlyIndex,        $expectedOnlyIndex],
+            [$mixedAddIndex,    $expectedMixedAddIndex],
+        ];
+    }
+}

--- a/test/Sql/Platform/Postgresql/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/AlterTableDecoratorTest.php
@@ -38,19 +38,19 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase {
         $noIndex = new Ddl\AlterTable('no_index');
         $noIndex->addColumn($newField_2);
 
+        $expectedNewFieldNoIndex = 'ALTER TABLE "no_index"' . "\n"
+                                 . ' ADD COLUMN "field_2" VARCHAR(1024) NOT NULL;';
+
         // AlterTable on its own
         $onlyIndex = new Ddl\AlterTable('only_index');
         $onlyIndex->addConstraint($newIdx);
+
+        $expectedOnlyIndex = 'CREATE INDEX "new_idx" ON "only_index"("field_1");';
 
         // AlterTable with Create Index
         $mixedAddIndex = new Ddl\AlterTable('mixed_index');
         $mixedAddIndex->addColumn($newField_2);
         $mixedAddIndex->addConstraint($newIdx);
-
-        $expectedNewFieldNoIndex = 'ALTER TABLE "no_index"' . "\n"
-                                 . ' ADD COLUMN "field_2" VARCHAR(1024) NOT NULL;';
-
-        $expectedOnlyIndex = 'CREATE INDEX "new_idx" ON "only_index"("field_1");';
 
         $expectedMixedAddIndex = 'ALTER TABLE "mixed_index"' . "\n"
                                . ' ADD COLUMN "field_2" VARCHAR(1024) NOT NULL;' . "\n"

--- a/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
@@ -44,10 +44,11 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $columnsOnly->addColumn($id);
         $columnsOnly->addColumn($name);
 
-        $expectedColumnsOnly = 'CREATE TABLE "columns_only" ( '."\n".
-            '    "id" INTEGER NOT NULL,'."\n".
-            '    "username" VARCHAR(1024) NOT NULL '."\n".
-            ');';
+        $expectedColumnsOnly =
+        'CREATE TABLE "columns_only" ( '."\n".
+        '    "id" INTEGER NOT NULL,'."\n".
+        '    "username" VARCHAR(1024) NOT NULL '."\n".
+        ');';
 
         return [
             [$columnsOnly, $expectedColumnsOnly]

--- a/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
@@ -19,7 +19,7 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
     /**
      * @testdox integration test: Testing CreateTableDecorator will use CreateTable as an internal state to adjust Index creation to be a separate statement
      * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::setSubject
-     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processConstraints
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::buildSqlString
      * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processIndexes
      * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processStatementEnd
      * @dataProvider tableDefinitionsProvider
@@ -38,20 +38,52 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $id = new Ddl\Column\Integer('id', false, null);
         $name = new Ddl\Column\Varchar('username', false, null);
         $name->setLength(1024);
+        $nameUnique = new Ddl\Constraint\UniqueKey('username');
+
+        $idIndex = new Ddl\Index\Index('id', 'id_idx');
+        $nameIndex = new Ddl\Index\Index('username', 'username_index');
 
 
         $columnsOnly = new CreateTable('columns_only');
         $columnsOnly->addColumn($id);
         $columnsOnly->addColumn($name);
 
-        $expectedColumnsOnly =
-        'CREATE TABLE "columns_only" ( '."\n".
-        '    "id" INTEGER NOT NULL,'."\n".
-        '    "username" VARCHAR(1024) NOT NULL '."\n".
-        ');';
+        $withSingleIndex = new CreateTable('with_single_index');
+        $withSingleIndex->addColumn($id);
+        $withSingleIndex->addColumn($name);
+        $withSingleIndex->addConstraint($idIndex);
+
+        $mixed = new CreateTable('mixed');
+        $mixed->addColumn($id);
+        $mixed->addColumn($name);
+        $mixed->addConstraint($nameUnique);
+        $mixed->addConstraint($idIndex);
+        $mixed->addConstraint($nameIndex);
+
+
+        $expectedColumnsOnly = 'CREATE TABLE "columns_only" ( ' . "\n"
+                             . '    "id" INTEGER NOT NULL,' . "\n"
+                             . '    "username" VARCHAR(1024) NOT NULL ' . "\n"
+                             . ');';
+
+        $expectedWithSingleInstance = 'CREATE TABLE "with_single_index" ( ' . "\n"
+                                    . '    "id" INTEGER NOT NULL,' . "\n"
+                                    . '    "username" VARCHAR(1024) NOT NULL ' . "\n"
+                                    . '); ' . "\n"
+                                    . 'CREATE INDEX "id_idx" ON "with_single_index"("id");';
+
+        $expectedMixed = 'CREATE TABLE "mixed" ( ' . "\n"
+                       . '    "id" INTEGER NOT NULL,' . "\n"
+                       . '    "username" VARCHAR(1024) NOT NULL , ' . "\n"
+                       . '    UNIQUE ("username") ' . "\n"
+                       . '); ' . "\n"
+                       . 'CREATE INDEX "id_idx" ON "mixed"("id");' . "\n"
+                       . 'CREATE INDEX "username_index" ON "mixed"("username");';
 
         return [
-            [$columnsOnly, $expectedColumnsOnly]
+            [$columnsOnly,      $expectedColumnsOnly],
+            [$withSingleIndex,  $expectedWithSingleInstance],
+            [$mixed,            $expectedMixed]
         ];
     }
 

--- a/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl;
+
+
+use Zend\Db\Adapter\Platform\Postgresql;
+use Zend\Db\Sql\Ddl\CreateTable;
+use Zend\Db\Sql\Ddl;
+
+class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox integration test: Testing CreateTableDecorator will use CreateTable as an internal state to adjust Index creation to be a separate statement
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::setSubject
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processConstraints
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processIndexes
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\CreateTableDecorator::processStatementEnd
+     * @dataProvider tableDefinitionsProvider
+     */
+    public function testGetSqlString(CreateTable $createTable, $expectedSql)
+    {
+        $createTableDecorator = new CreateTableDecorator();
+        $createTableDecorator->setSubject($createTable);
+
+        $createTableSql = $createTableDecorator->getSqlString(new Postgresql());
+        $this->assertEquals($expectedSql, $createTableSql);
+    }
+
+    public function tableDefinitionsProvider()
+    {
+        $id = new Ddl\Column\Integer('id', false, null);
+        $name = new Ddl\Column\Varchar('username', false, null);
+        $name->setLength(1024);
+
+
+        $columnsOnly = new CreateTable('columns_only');
+        $columnsOnly->addColumn($id);
+        $columnsOnly->addColumn($name);
+
+        $expectedColumnsOnly = 'CREATE TABLE "columns_only" ( '."\n".
+            '    "id" INTEGER NOT NULL,'."\n".
+            '    "username" VARCHAR(1024) NOT NULL '."\n".
+            ');';
+
+        return [
+            [$columnsOnly, $expectedColumnsOnly]
+        ];
+    }
+
+}

--- a/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
@@ -43,34 +43,36 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $idIndex = new Ddl\Index\Index('id', 'id_idx');
         $nameIndex = new Ddl\Index\Index('username', 'username_index');
 
-
+        // CREATE TABLE only.
         $columnsOnly = new CreateTable('columns_only');
         $columnsOnly->addColumn($id);
         $columnsOnly->addColumn($name);
-
-        $withSingleIndex = new CreateTable('with_single_index');
-        $withSingleIndex->addColumn($id);
-        $withSingleIndex->addColumn($name);
-        $withSingleIndex->addConstraint($idIndex);
-
-        $mixed = new CreateTable('mixed');
-        $mixed->addColumn($id);
-        $mixed->addColumn($name);
-        $mixed->addConstraint($nameUnique);
-        $mixed->addConstraint($idIndex);
-        $mixed->addConstraint($nameIndex);
-
 
         $expectedColumnsOnly = 'CREATE TABLE "columns_only" ( ' . "\n"
                              . '    "id" INTEGER NOT NULL,' . "\n"
                              . '    "username" VARCHAR(1024) NOT NULL ' . "\n"
                              . ');';
 
+        // CreateTable with Create Index
+        $withSingleIndex = new CreateTable('with_single_index');
+        $withSingleIndex->addColumn($id);
+        $withSingleIndex->addColumn($name);
+        $withSingleIndex->addConstraint($idIndex);
+
         $expectedWithSingleInstance = 'CREATE TABLE "with_single_index" ( ' . "\n"
                                     . '    "id" INTEGER NOT NULL,' . "\n"
                                     . '    "username" VARCHAR(1024) NOT NULL ' . "\n"
                                     . '); ' . "\n"
                                     . 'CREATE INDEX "id_idx" ON "with_single_index"("id");';
+
+
+        // Mixed handling of index separation from constraints.
+        $mixed = new CreateTable('mixed');
+        $mixed->addColumn($id);
+        $mixed->addColumn($name);
+        $mixed->addConstraint($nameUnique);
+        $mixed->addConstraint($idIndex);
+        $mixed->addConstraint($nameIndex);
 
         $expectedMixed = 'CREATE TABLE "mixed" ( ' . "\n"
                        . '    "id" INTEGER NOT NULL,' . "\n"

--- a/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/CreateTableDecoratorTest.php
@@ -83,7 +83,7 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
         return [
             [$columnsOnly,      $expectedColumnsOnly],
             [$withSingleIndex,  $expectedWithSingleInstance],
-            [$mixed,            $expectedMixed]
+            [$mixed,            $expectedMixed],
         ];
     }
 

--- a/test/Sql/Platform/Postgresql/Ddl/Index/IndexDecoratorTest.php
+++ b/test/Sql/Platform/Postgresql/Ddl/Index/IndexDecoratorTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\Postgresql\Ddl\Index;
+
+use Zend\Db\Adapter\Exception\InvalidQueryException;
+use Zend\Db\Sql\Ddl\Index\Index;
+
+class IndexDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\Index\IndexDecorator::setSubject
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\Index\IndexDecorator::setTable
+     * @covers Zend\Db\Sql\Platform\Postgresql\Ddl\Index\IndexDecorator::getExpressionData
+     */
+    public function testSpecificationHasCreateOnTable()
+    {
+        $index = new Index();
+        $index->setName('test_index');
+        $index->setColumns(['test_column_one', 'test_column_two']);
+
+        $postgresIndex = new IndexDecorator();
+        $postgresIndex->setSubject($index);
+        $postgresIndex->setTable('test_table'); // PostgreSQL must have table name to operate on, unlike other engines
+
+        $expressionData = $postgresIndex->getExpressionData()[0];
+
+        // [0] => specification
+        // [1] => values
+        // [2] => types
+        $this->assertEquals('CREATE INDEX %s ON %s(%s, %s)', $expressionData[0]);
+        $this->assertEquals(['test_index', 'test_table', 'test_column_one', 'test_column_two'], $expressionData[1]);
+        $this->assertEquals(
+            [Index::TYPE_IDENTIFIER, Index::TYPE_IDENTIFIER, Index::TYPE_IDENTIFIER, Index::TYPE_IDENTIFIER],
+            $expressionData[2]
+        );
+    }
+
+    public function testExceptionThrownIfNoTableSpecified()
+    {
+        $postgresIndex = new IndexDecorator();
+
+        $this->setExpectedException(InvalidQueryException::class);
+        $postgresIndex->getExpressionData();
+    }
+}

--- a/test/Sql/Platform/Postgresql/PostgresqlTest.php
+++ b/test/Sql/Platform/Postgresql/PostgresqlTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform;
+
+use Zend\Db\Sql\Platform\Postgresql\Postgresql;
+use Zend\Db\Sql\Platform\Postgresql\Ddl;
+
+class PostgresqlTest extends \PHPUnit_Framework_TestCase {
+    /*
+    * @testdox unit test / object test:
+    * @covers Zend\Db\Sql\Platform\Postgresql\Postgresql::__construct
+    */
+    public function testConstruct()
+    {
+
+    }
+}

--- a/test/Sql/Platform/Postgresql/PostgresqlTest.php
+++ b/test/Sql/Platform/Postgresql/PostgresqlTest.php
@@ -14,11 +14,15 @@ use Zend\Db\Sql\Platform\Postgresql\Ddl;
 
 class PostgresqlTest extends \PHPUnit_Framework_TestCase {
     /*
-    * @testdox unit test / object test:
+    * @testdox unit test / object test: Has CreateTable proxy
     * @covers Zend\Db\Sql\Platform\Postgresql\Postgresql::__construct
     */
     public function testConstruct()
     {
+        $postgresql = new Postgresql();
+        $decorators = $postgresql->getDecorators();
 
+        $this->assertArrayHasKey('Zend\Db\Sql\Ddl\CreateTable', $decorators);
+        $this->assertInstanceOf(Ddl\CreateTableDecorator::class, $decorators['Zend\Db\Sql\Ddl\CreateTable']);
     }
 }

--- a/test/Sql/Platform/Postgresql/PostgresqlTest.php
+++ b/test/Sql/Platform/Postgresql/PostgresqlTest.php
@@ -24,5 +24,7 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertArrayHasKey('Zend\Db\Sql\Ddl\CreateTable', $decorators);
         $this->assertInstanceOf(Ddl\CreateTableDecorator::class, $decorators['Zend\Db\Sql\Ddl\CreateTable']);
+        $this->assertArrayHasKey('Zend\Db\Sql\Ddl\AlterTable', $decorators);
+        $this->assertInstanceOf(Ddl\AlterTableDecorator::class, $decorators['Zend\Db\Sql\Ddl\AlterTable']);
     }
 }

--- a/test/TestAsset/TrustingPostgresqlPlatform.php
+++ b/test/TestAsset/TrustingPostgresqlPlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Postgresql;
+
+class TrustingPostgresqlPlatform extends Postgresql
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}


### PR DESCRIPTION
Add support for Index creation with PostgreSQL platform. 
$table = CreateTable();
$table->addConstraint(new Index())
crashed with invalid syntax error.  Same for AlterTable.

Can be considered as first step towards cleaning up #67 
Continuing to work on finding the rest of the incompatibilities, but not sure if submit one large PR with full PgSQL support or do smaller more review manageable parts at a time. But then cannot make PRs depend on one another so, unless told otherwise will continue adding more commits here.