### PR TITLE
Added default 'db' configuration

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,6 +17,7 @@ class ConfigProvider
     public function __invoke()
     {
         return [
+            'db'           => $this->getDefaultDbConfig(),
             'dependencies' => $this->getDependencyConfig(),
         ];
     }
@@ -38,6 +39,14 @@ class ConfigProvider
             'aliases' => [
                 Adapter\Adapter::class => Adapter\AdapterInterface::class,
             ],
+        ];
+    }
+
+    public function getDefaultDbConfig()
+    {
+        return [
+            'driver' => 'Pdo',
+            'dsn'    => 'sqlite::memory:',
         ];
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -18,6 +18,7 @@ class Module
     {
         $provider = new ConfigProvider();
         return [
+            'db'              => $provider->getDefaultDbConfig(),
             'service_manager' => $provider->getDependencyConfig(),
         ];
     }


### PR DESCRIPTION
Defines a default adapter using an in-memory SQLite database. This is done to prevent failurs when adding zend-db to an application that retrieves the adapter via the container:

``` php
$container->get(\Zend\Db\Adapter\AdapterInterface::class)
```

This was observed when adding ZendDeveloperTools to a ZF3 application while also installing zend-db, but without first configuring zend-db.

Reported at zendframework/tutorials#57
