### PR TITLE
Metadata\Source\Factory throws specific exception

### DIFF
--- a/src/Metadata/Source/Exception/ExceptionInterface.php
+++ b/src/Metadata/Source/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Metadata\Source\Exception;
+
+use Zend\Db\Exception;
+
+interface ExceptionInterface extends Exception\ExceptionInterface
+{
+}

--- a/src/Metadata/Source/Exception/InvalidArgumentException.php
+++ b/src/Metadata/Source/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Metadata\Source\Exception;
+
+use Zend\Db\Exception;
+
+class InvalidArgumentException extends Exception\InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Metadata/Source/Factory.php
+++ b/src/Metadata/Source/Factory.php
@@ -10,8 +10,8 @@
 namespace Zend\Db\Metadata\Source;
 
 use Zend\Db\Adapter\Adapter;
-use Zend\Db\Exception\InvalidArgumentException;
 use Zend\Db\Metadata\MetadataInterface;
+use Zend\Db\Metadata\Source\Exception;
 
 /**
  * Source metadata factory.
@@ -23,7 +23,7 @@ class Factory
      *
      * @param  Adapter $adapter
      * @return MetadataInterface
-     * @throws InvalidArgumentException If adapter platform name not recognized.
+     * @throws Exception\InvalidArgumentException If adapter platform name not recognized.
      */
     public static function createSourceFromAdapter(Adapter $adapter)
     {
@@ -41,7 +41,7 @@ class Factory
             case 'Oracle':
                 return new OracleMetadata($adapter);
             default:
-                throw new InvalidArgumentException("Unknown adapter platform '{$platformName}'");
+                throw new Exception\InvalidArgumentException("Unknown adapter platform '{$platformName}'");
         }
     }
 }

--- a/test/Metadata/Source/FactoryTest.php
+++ b/test/Metadata/Source/FactoryTest.php
@@ -18,7 +18,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      * @dataProvider validAdapterProvider
      *
      * @param Adapter $adapter
-     * @param string $expectedReturnClass
+     * @param string  $expectedReturnClass
      */
     public function testCreateSourceFromAdapter(Adapter $adapter, $expectedReturnClass)
     {
@@ -30,35 +30,47 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function validAdapterProvider()
     {
-        $createAdapterForPlatform = function ($platformName) {
-            $platform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
-            $platform
-                ->expects($this->any())
-                ->method('getName')
-                ->willReturn($platformName)
-            ;
-
-            $adapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
-                ->disableOriginalConstructor()
-                ->getMock()
-            ;
-
-            $adapter
-                ->expects($this->any())
-                ->method('getPlatform')
-                ->willReturn($platform)
-            ;
-
-            return $adapter;
-        };
-
         return [
             // Description => [adapter, expected return class]
-            'MySQL' => [$createAdapterForPlatform('MySQL'), 'Zend\Db\Metadata\Source\MysqlMetadata'],
-            'SQLServer' => [$createAdapterForPlatform('SQLServer'), 'Zend\Db\Metadata\Source\SqlServerMetadata'],
-            'SQLite' => [$createAdapterForPlatform('SQLite'), 'Zend\Db\Metadata\Source\SqliteMetadata'],
-            'PostgreSQL' => [$createAdapterForPlatform('PostgreSQL'), 'Zend\Db\Metadata\Source\PostgresqlMetadata'],
-            'Oracle' => [$createAdapterForPlatform('Oracle'), 'Zend\Db\Metadata\Source\OracleMetadata'],
+            'MySQL' => [$this->createAdapterForPlatform('MySQL'), 'Zend\Db\Metadata\Source\MysqlMetadata'],
+            'SQLServer' => [$this->createAdapterForPlatform('SQLServer'), 'Zend\Db\Metadata\Source\SqlServerMetadata'],
+            'SQLite' => [$this->createAdapterForPlatform('SQLite'), 'Zend\Db\Metadata\Source\SqliteMetadata'],
+            'PostgreSQL' => [$this->createAdapterForPlatform('PostgreSQL'), 'Zend\Db\Metadata\Source\PostgresqlMetadata'],
+            'Oracle' => [$this->createAdapterForPlatform('Oracle'), 'Zend\Db\Metadata\Source\OracleMetadata'],
         ];
+    }
+
+    public function testCreateSourceFromAdapterWhenAdapterIsNotSupportedThrowsException()
+    {
+        $this->setExpectedException('Zend\Db\Metadata\Source\Exception\InvalidArgumentException', "Unknown adapter platform 'unknown-platform'");
+        Factory::createSourceFromAdapter($this->createAdapterForPlatform('unknown-platform'));
+    }
+
+    /**
+     * @param string $platformName
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createAdapterForPlatform($platformName)
+    {
+        $platform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
+        $platform
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn($platformName)
+        ;
+
+        $adapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $adapter
+            ->expects($this->any())
+            ->method('getPlatform')
+            ->willReturn($platform)
+        ;
+
+        return $adapter;
     }
 }


### PR DESCRIPTION
Metadata\Source\Factory throws specific exception when the platform is not supported.

It will help to catch this specific exception in zf-apigility-admin,
matching exception by text is too fragile.

https://github.com/zfcampus/zf-apigility-admin/pull/365/files