### PR TITLE
Add $this->select to the output of getRawState() in Sql/Insert.php (Issue 175)

### DIFF
--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -160,7 +160,8 @@ class Insert extends AbstractPreparableSql
         $rawState = [
             'table' => $this->table,
             'columns' => array_keys($this->columns),
-            'values' => array_values($this->columns)
+            'values' => array_values($this->columns),
+            'select' => $this->select
         ];
         return (isset($key) && array_key_exists($key, $rawState)) ? $rawState[$key] : $rawState;
     }

--- a/test/Sql/InsertTest.php
+++ b/test/Sql/InsertTest.php
@@ -125,6 +125,16 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\Sql\Insert::select
+     */
+    public function testSelectIncludedInRawState()
+    {
+        $select = new Select;
+        $this->insert->select($select);
+        $this->assertSame($select, $this->insert->getRawState('select'));
+    }
+
+    /**
      * @covers Zend\Db\Sql\Insert::prepareStatement
      */
     public function testPrepareStatement()


### PR DESCRIPTION
Per Issue #175, this PR simply adds `$this->select` to the output of `getRawState()` (or `getRawState('select')`).  This is parallel to the way `Select::getRawState()` returns values, objects, or `null` - specifically, the way `Select` returns objects for: `having`, `table`, `where`.

That is, `getRawState()` does not have to only return scalars, arrays, or `null` - it can also return objects.  Therefore, this PR does not have `getRawState('select')` return the `getRawState()` of that `select` value (that is, this PR `$insert->getRawState('select')` is _not_ the same as `$insert->getRawState($select->getRawState())`).
