### PR TITLE
Fix PDO parameter names

### DIFF
--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -298,7 +298,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && !is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
-            return ':' . $name;
+            return ':' . preg_replace('/[^a-zA-Z0-9_]/', '_', $name);
         }
 
         return '?';

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -182,7 +182,7 @@ class Insert extends AbstractPreparableSql
             if (is_scalar($value) && $parameterContainer) {
                 $parameterName = $driver->formatParameterName($column);
                 $values[] = $parameterName;
-                if ($parameterName == '?') {
+                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_POSITIONAL or $parameterName == '?') {
                     $parameterContainer->offsetSet($column, $value);
                 } else {
                     $parameterContainer->offsetSet(substr($parameterName, 1), $value);

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -180,8 +180,13 @@ class Insert extends AbstractPreparableSql
         foreach ($this->columns as $column => $value) {
             $columns[] = $platform->quoteIdentifier($column);
             if (is_scalar($value) && $parameterContainer) {
-                $values[] = $driver->formatParameterName($column);
-                $parameterContainer->offsetSet($column, $value);
+                $parameterName = $driver->formatParameterName($column);
+                $values[] = $parameterName;
+                if ($parameterName == '?') {
+                    $parameterContainer->offsetSet($column, $value);
+                } else {
+                    $parameterContainer->offsetSet(substr($parameterName, 1), $value);
+                }
             } else {
                 $values[] = $this->resolveColumnValue(
                     $value,

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -182,10 +182,10 @@ class Insert extends AbstractPreparableSql
             if (is_scalar($value) && $parameterContainer) {
                 $parameterName = $driver->formatParameterName($column);
                 $values[] = $parameterName;
-                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_POSITIONAL or $parameterName == '?') {
-                    $parameterContainer->offsetSet($column, $value);
-                } else {
+                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_NAMED and $parameterName != '?') {
                     $parameterContainer->offsetSet(substr($parameterName, 1), $value);
+                } else {
+                    $parameterContainer->offsetSet($column, $value);
                 }
             } else {
                 $values[] = $this->resolveColumnValue(

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -183,8 +183,13 @@ class Update extends AbstractPreparableSql
         foreach ($this->set as $column => $value) {
             $prefix = $platform->quoteIdentifier($column) . ' = ';
             if (is_scalar($value) && $parameterContainer) {
-                $setSql[] = $prefix . $driver->formatParameterName($column);
-                $parameterContainer->offsetSet($column, $value);
+                $parameterName = $driver->formatParameterName($column);
+                $setSql[] = $prefix . $parameterName;
+                if ($parameterName == '?') {
+                    $parameterContainer->offsetSet($column, $value);
+                } else {
+                    $parameterContainer->offsetSet(substr($parameterName, 1), $value);
+                }
             } else {
                 $setSql[] = $prefix . $this->resolveColumnValue(
                     $value,

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -185,10 +185,10 @@ class Update extends AbstractPreparableSql
             if (is_scalar($value) && $parameterContainer) {
                 $parameterName = $driver->formatParameterName($column);
                 $setSql[] = $prefix . $parameterName;
-                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_POSITIONAL or $parameterName == '?') {
-                    $parameterContainer->offsetSet($column, $value);
-                } else {
+                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_NAMED and $parameterName != '?') {
                     $parameterContainer->offsetSet(substr($parameterName, 1), $value);
+                } else {
+                    $parameterContainer->offsetSet($column, $value);
                 }
             } else {
                 $setSql[] = $prefix . $this->resolveColumnValue(

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -185,7 +185,7 @@ class Update extends AbstractPreparableSql
             if (is_scalar($value) && $parameterContainer) {
                 $parameterName = $driver->formatParameterName($column);
                 $setSql[] = $prefix . $parameterName;
-                if ($parameterName == '?') {
+                if ($driver->getPrepareType() == $driver::PARAMETERIZATION_POSITIONAL or $parameterName == '?') {
                     $parameterContainer->offsetSet($column, $value);
                 } else {
                     $parameterContainer->offsetSet(substr($parameterName, 1), $value);

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -38,4 +38,17 @@ class PdoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SqlServer', $this->pdo->getDatabasePlatformName());
         $this->assertEquals('SQLServer', $this->pdo->getDatabasePlatformName(DriverInterface::NAME_FORMAT_NATURAL));
     }
+
+    /**
+     * @covers Zend\Db\Adapter\Driver\Pdo\Pdo::formatParameterName
+     */
+    public function testFormatParameterName()
+    {
+        $this->assertEquals('?', $this->pdo->formatParameterName(1));
+        $this->assertEquals(':testName', $this->pdo->formatParameterName('testName'));
+        $this->assertEquals(':testName_', $this->pdo->formatParameterName('testName_'));
+        $this->assertEquals(':testName1', $this->pdo->formatParameterName('testName1'));
+        $this->assertEquals(':testName_', $this->pdo->formatParameterName('testName$'));
+        $this->assertEquals(':testName_', $this->pdo->formatParameterName('testName#'));
+    }
 }


### PR DESCRIPTION
It appears that PDO only allows alphanumeric and underscore characters ([a-zA-Z0-9_]) for placeholder parameter names. However, the zend-db pdo driver just passes on anything without regard to those limitations. This patch addresses that by replacing any non-allowable characters with an underscore.

This is needed because various databases you might access through the PDO driver support more characters than that unquoted. For example MySQL also supports a dollar sign ($) and DB2 on the IBM i (I'm using this via PDO ODBC) supports the dollar sign and the hash/pound sign (#). (Side note - it works fine using the IbmDb2 driver which does positional parameters, but that is only available if you have that built in to PHP and are running it directly on the DB2 server or have purchased DB2 Connect)

I believe this addresses issue #35 though obviously not by changing to positional parameters as suggested there.
