### PR TITLE
Add consistency to method chaining DocBlocks

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -101,7 +101,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Adapter Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {

--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -101,7 +101,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Adapter
+     * @return Adapter Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {

--- a/src/Adapter/AdapterAwareTrait.php
+++ b/src/Adapter/AdapterAwareTrait.php
@@ -20,7 +20,7 @@ trait AdapterAwareTrait
      * Set db adapter
      *
      * @param Adapter $adapter
-     * @return AdapterAwareTrait Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDbAdapter(Adapter $adapter)
     {

--- a/src/Adapter/AdapterAwareTrait.php
+++ b/src/Adapter/AdapterAwareTrait.php
@@ -20,7 +20,7 @@ trait AdapterAwareTrait
      * Set db adapter
      *
      * @param Adapter $adapter
-     * @return mixed
+     * @return AdapterAwareTrait Provides a fluent interface
      */
     public function setDbAdapter(Adapter $adapter)
     {

--- a/src/Adapter/Driver/AbstractConnection.php
+++ b/src/Adapter/Driver/AbstractConnection.php
@@ -112,7 +112,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
 
     /**
      * @param  array $connectionParameters
-     * @return AbstractConnection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setConnectionParameters(array $connectionParameters)
     {
@@ -124,7 +124,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
     /**
      * {@inheritDoc}
      *
-     * @return AbstractConnection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(ProfilerInterface $profiler)
     {

--- a/src/Adapter/Driver/AbstractConnection.php
+++ b/src/Adapter/Driver/AbstractConnection.php
@@ -112,7 +112,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
 
     /**
      * @param  array $connectionParameters
-     * @return self
+     * @return AbstractConnection Provides a fluent interface
      */
     public function setConnectionParameters(array $connectionParameters)
     {
@@ -124,7 +124,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
     /**
      * {@inheritDoc}
      *
-     * @return self
+     * @return AbstractConnection Provides a fluent interface
      */
     public function setProfiler(ProfilerInterface $profiler)
     {

--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -56,7 +56,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  IbmDb2 $driver
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -67,7 +67,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  resource $resource DB2 resource
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -203,7 +203,8 @@ class Connection extends AbstractConnection
     /**
      * Rollback
      *
-     * @return Connection
+     * @return Connection Provides a fluent interface
+     * @throws Exception\RuntimeException
      */
     public function rollback()
     {

--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -56,7 +56,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  IbmDb2 $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -67,7 +67,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  resource $resource DB2 resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -203,7 +203,7 @@ class Connection extends AbstractConnection
     /**
      * Rollback
      *
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function rollback()

--- a/src/Adapter/Driver/IbmDb2/IbmDb2.php
+++ b/src/Adapter/Driver/IbmDb2/IbmDb2.php
@@ -49,7 +49,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return IbmDb2 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -73,7 +73,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Connection $connection
-     * @return IbmDb2 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -84,7 +84,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Statement $statementPrototype
-     * @return IbmDb2 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -95,7 +95,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Result $resultPrototype
-     * @return IbmDb2 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/IbmDb2/IbmDb2.php
+++ b/src/Adapter/Driver/IbmDb2/IbmDb2.php
@@ -49,7 +49,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return IbmDb2
+     * @return IbmDb2 Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -73,7 +73,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Connection $connection
-     * @return IbmDb2
+     * @return IbmDb2 Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -84,7 +84,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Statement $statementPrototype
-     * @return IbmDb2
+     * @return IbmDb2 Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -95,7 +95,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Result $resultPrototype
-     * @return IbmDb2
+     * @return IbmDb2 Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/IbmDb2/Result.php
+++ b/src/Adapter/Driver/IbmDb2/Result.php
@@ -42,7 +42,7 @@ class Result implements ResultInterface
     /**
      * @param  resource $resource
      * @param  mixed $generatedValue
-     * @return Result
+     * @return Result Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/IbmDb2/Result.php
+++ b/src/Adapter/Driver/IbmDb2/Result.php
@@ -42,7 +42,7 @@ class Result implements ResultInterface
     /**
      * @param  resource $resource
      * @param  mixed $generatedValue
-     * @return Result Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -53,7 +53,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param $resource
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function initialize($resource)
     {
@@ -63,7 +63,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param IbmDb2 $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -73,7 +73,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -93,7 +93,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param $sql
-     * @return mixed
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -115,7 +115,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return mixed
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -159,7 +159,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare sql
      *
      * @param string|null $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
+     * @throws Exception\RuntimeException
      */
     public function prepare($sql = null)
     {

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -53,7 +53,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param $resource
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize($resource)
     {
@@ -63,7 +63,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param IbmDb2 $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -73,7 +73,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -93,7 +93,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -115,7 +115,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -159,7 +159,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare sql
      *
      * @param string|null $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function prepare($sql = null)

--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -43,7 +43,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  Mysqli $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -72,7 +72,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  \mysqli $resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(\mysqli $resource)
     {

--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -43,7 +43,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  Mysqli $driver
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -72,7 +72,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  \mysqli $resource
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setResource(\mysqli $resource)
     {

--- a/src/Adapter/Driver/Mysqli/Mysqli.php
+++ b/src/Adapter/Driver/Mysqli/Mysqli.php
@@ -66,7 +66,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Mysqli Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -92,7 +92,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Mysqli Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {

--- a/src/Adapter/Driver/Mysqli/Mysqli.php
+++ b/src/Adapter/Driver/Mysqli/Mysqli.php
@@ -66,7 +66,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Mysqli
+     * @return Mysqli Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -92,7 +92,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Mysqli
+     * @return Mysqli Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {

--- a/src/Adapter/Driver/Mysqli/Result.php
+++ b/src/Adapter/Driver/Mysqli/Result.php
@@ -72,7 +72,7 @@ class Result implements
      * @param mixed $resource
      * @param mixed $generatedValue
      * @param bool|null $isBuffered
-     * @return Result Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($resource, $generatedValue, $isBuffered = null)

--- a/src/Adapter/Driver/Mysqli/Result.php
+++ b/src/Adapter/Driver/Mysqli/Result.php
@@ -72,8 +72,8 @@ class Result implements
      * @param mixed $resource
      * @param mixed $generatedValue
      * @param bool|null $isBuffered
+     * @return Result Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Result
      */
     public function initialize($resource, $generatedValue, $isBuffered = null)
     {

--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -72,7 +72,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Mysqli $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -82,7 +82,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -102,7 +102,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  \mysqli $mysqli
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize(\mysqli $mysqli)
     {
@@ -114,7 +114,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -126,7 +126,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set Parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -148,7 +148,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  \mysqli_stmt $mysqliStatement
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(\mysqli_stmt $mysqliStatement)
     {
@@ -191,7 +191,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare
      *
      * @param string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidQueryException
      * @throws Exception\RuntimeException
      */

--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -72,7 +72,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Mysqli $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -82,7 +82,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -102,7 +102,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  \mysqli $mysqli
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function initialize(\mysqli $mysqli)
     {
@@ -114,7 +114,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -126,7 +126,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set Parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -148,7 +148,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  \mysqli_stmt $mysqliStatement
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setResource(\mysqli_stmt $mysqliStatement)
     {
@@ -191,9 +191,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare
      *
      * @param string $sql
+     * @return Statement Provides a fluent interface
      * @throws Exception\InvalidQueryException
      * @throws Exception\RuntimeException
-     * @return Statement
      */
     public function prepare($sql = null)
     {

--- a/src/Adapter/Driver/Oci8/Connection.php
+++ b/src/Adapter/Driver/Oci8/Connection.php
@@ -38,7 +38,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  Oci8 $driver
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(Oci8 $driver)
     {
@@ -68,7 +68,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  resource $resource
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setResource($resource)
     {

--- a/src/Adapter/Driver/Oci8/Connection.php
+++ b/src/Adapter/Driver/Oci8/Connection.php
@@ -38,7 +38,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  Oci8 $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Oci8 $driver)
     {
@@ -68,7 +68,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  resource $resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource($resource)
     {

--- a/src/Adapter/Driver/Oci8/Oci8.php
+++ b/src/Adapter/Driver/Oci8/Oci8.php
@@ -82,7 +82,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Oci8
+     * @return Oci8 Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -108,7 +108,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Oci8
+     * @return Oci8 Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -121,7 +121,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statementPrototype
-     * @return Oci8
+     * @return Oci8 Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -142,7 +142,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $resultPrototype
-     * @return Oci8
+     * @return Oci8 Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {
@@ -163,7 +163,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return self
+     * @return Oci8 Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -178,7 +178,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Setup the default features for Pdo
      *
-     * @return self
+     * @return Oci8 Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Oci8/Oci8.php
+++ b/src/Adapter/Driver/Oci8/Oci8.php
@@ -82,7 +82,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -108,7 +108,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -121,7 +121,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statementPrototype
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -142,7 +142,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $resultPrototype
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {
@@ -163,7 +163,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -178,7 +178,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Setup the default features for Pdo
      *
-     * @return Oci8 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Oci8/Result.php
+++ b/src/Adapter/Driver/Oci8/Result.php
@@ -64,7 +64,7 @@ class Result implements Iterator, ResultInterface
      * @param resource $resource
      * @param null|int $generatedValue
      * @param null|int $rowCount
-     * @return Result
+     * @return Result Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null, $rowCount = null)
     {

--- a/src/Adapter/Driver/Oci8/Result.php
+++ b/src/Adapter/Driver/Oci8/Result.php
@@ -64,7 +64,7 @@ class Result implements Iterator, ResultInterface
      * @param resource $resource
      * @param null|int $generatedValue
      * @param null|int $rowCount
-     * @return Result Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null, $rowCount = null)
     {

--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -64,7 +64,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Oci8 $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver($driver)
     {
@@ -74,7 +74,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -94,7 +94,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  resource $oci8
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function initialize($oci8)
     {
@@ -106,7 +106,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -118,7 +118,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set Parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -140,7 +140,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  resource $oci8Statement
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setResource($oci8Statement)
     {
@@ -184,7 +184,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function prepare($sql = null)
     {

--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -64,7 +64,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Oci8 $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver($driver)
     {
@@ -74,7 +74,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -94,7 +94,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  resource $oci8
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize($oci8)
     {
@@ -106,7 +106,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -118,7 +118,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set Parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -140,7 +140,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  resource $oci8Statement
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource($oci8Statement)
     {
@@ -184,7 +184,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function prepare($sql = null)
     {

--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -52,7 +52,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param Pdo $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -137,7 +137,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  \PDO $resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(\PDO $resource)
     {

--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -51,8 +51,8 @@ class Connection extends AbstractConnection
     /**
      * Set driver
      *
-     * @param  Pdo  $driver
-     * @return self
+     * @param Pdo $driver
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -137,7 +137,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  \PDO $resource
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setResource(\PDO $resource)
     {

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -71,7 +71,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Pdo
+     * @return Pdo Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -97,7 +97,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
      * Register connection
      *
      * @param  Connection $connection
-     * @return Pdo
+     * @return Pdo Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -132,7 +132,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return Pdo
+     * @return Pdo Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -147,7 +147,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     /**
      * Setup the default features for Pdo
      *
-     * @return Pdo
+     * @return Pdo Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -71,7 +71,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Pdo Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -97,7 +97,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
      * Register connection
      *
      * @param  Connection $connection
-     * @return Pdo Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -132,7 +132,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return Pdo Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -147,7 +147,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     /**
      * Setup the default features for Pdo
      *
-     * @return Pdo Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -74,7 +74,7 @@ class Result implements Iterator, ResultInterface
      * @param  PDOStatement $resource
      * @param               $generatedValue
      * @param  int          $rowCount
-     * @return Result
+     * @return Result Provides a fluent interface
      */
     public function initialize(PDOStatement $resource, $generatedValue, $rowCount = null)
     {

--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -74,7 +74,7 @@ class Result implements Iterator, ResultInterface
      * @param  PDOStatement $resource
      * @param               $generatedValue
      * @param  int          $rowCount
-     * @return Result Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize(PDOStatement $resource, $generatedValue, $rowCount = null)
     {

--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -69,7 +69,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Pdo $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -79,7 +79,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -99,7 +99,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  \PDO $connectionResource
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize(\PDO $connectionResource)
     {
@@ -111,7 +111,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  \PDOStatement $pdoStatement
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(\PDOStatement $pdoStatement)
     {
@@ -133,7 +133,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -153,7 +153,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -69,7 +69,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Pdo $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -79,7 +79,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -99,7 +99,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  \PDO $connectionResource
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function initialize(\PDO $connectionResource)
     {
@@ -111,7 +111,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  \PDOStatement $pdoStatement
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setResource(\PDOStatement $pdoStatement)
     {
@@ -133,7 +133,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -153,7 +153,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param ParameterContainer $parameterContainer
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -47,7 +47,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param resource $resource
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -61,7 +61,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  Pgsql $driver
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -72,7 +72,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param int|null $type
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setType($type)
     {

--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -47,7 +47,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param resource $resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -61,7 +61,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  Pgsql $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -72,7 +72,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param int|null $type
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setType($type)
     {

--- a/src/Adapter/Driver/Pgsql/Pgsql.php
+++ b/src/Adapter/Driver/Pgsql/Pgsql.php
@@ -61,6 +61,10 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
         $this->registerResultPrototype(($resultPrototype) ?: new Result());
     }
 
+    /**
+     * @param Profiler\ProfilerInterface $profiler
+     * @return Pgsql Provides a fluent interface
+     */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
         $this->profiler = $profiler;
@@ -85,7 +89,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param Connection $connection
-     * @return Pgsql
+     * @return Pgsql Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -98,7 +102,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statement
-     * @return Pgsql
+     * @return Pgsql Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statement)
     {
@@ -111,7 +115,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $result
-     * @return Pgsql
+     * @return Pgsql Provides a fluent interface
      */
     public function registerResultPrototype(Result $result)
     {

--- a/src/Adapter/Driver/Pgsql/Pgsql.php
+++ b/src/Adapter/Driver/Pgsql/Pgsql.php
@@ -63,7 +63,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Pgsql Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -89,7 +89,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param Connection $connection
-     * @return Pgsql Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -102,7 +102,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statement
-     * @return Pgsql Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statement)
     {
@@ -115,7 +115,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $result
-     * @return Pgsql Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerResultPrototype(Result $result)
     {

--- a/src/Adapter/Driver/Pgsql/Statement.php
+++ b/src/Adapter/Driver/Pgsql/Statement.php
@@ -58,7 +58,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Pgsql $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -68,7 +68,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -117,7 +117,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -139,7 +139,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Pgsql/Statement.php
+++ b/src/Adapter/Driver/Pgsql/Statement.php
@@ -58,7 +58,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param  Pgsql $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -68,7 +68,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -117,7 +117,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -139,7 +139,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Sqlsrv/Connection.php
+++ b/src/Adapter/Driver/Sqlsrv/Connection.php
@@ -41,7 +41,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  Sqlsrv $driver
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -69,7 +69,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  resource $resource
-     * @return Connection Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setResource($resource)

--- a/src/Adapter/Driver/Sqlsrv/Connection.php
+++ b/src/Adapter/Driver/Sqlsrv/Connection.php
@@ -41,7 +41,7 @@ class Connection extends AbstractConnection
      * Set driver
      *
      * @param  Sqlsrv $driver
-     * @return self
+     * @return Connection Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -68,9 +68,9 @@ class Connection extends AbstractConnection
     /**
      * Set resource
      *
-     * @param  resource                           $resource
+     * @param  resource $resource
+     * @return Connection Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
     public function setResource($resource)
     {

--- a/src/Adapter/Driver/Sqlsrv/Result.php
+++ b/src/Adapter/Driver/Sqlsrv/Result.php
@@ -46,7 +46,7 @@ class Result implements Iterator, ResultInterface
      *
      * @param  resource $resource
      * @param  mixed    $generatedValue
-     * @return Result Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/Sqlsrv/Result.php
+++ b/src/Adapter/Driver/Sqlsrv/Result.php
@@ -46,7 +46,7 @@ class Result implements Iterator, ResultInterface
      *
      * @param  resource $resource
      * @param  mixed    $generatedValue
-     * @return Result
+     * @return Result Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -53,7 +53,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Sqlsrv
+     * @return Sqlsrv Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -79,7 +79,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Sqlsrv
+     * @return Sqlsrv Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -92,7 +92,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statementPrototype
-     * @return Sqlsrv
+     * @return Sqlsrv Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -105,7 +105,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $resultPrototype
-     * @return Sqlsrv
+     * @return Sqlsrv Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -53,7 +53,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Sqlsrv Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -79,7 +79,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register connection
      *
      * @param  Connection $connection
-     * @return Sqlsrv Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -92,7 +92,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register statement prototype
      *
      * @param Statement $statementPrototype
-     * @return Sqlsrv Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -105,7 +105,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
      * Register result prototype
      *
      * @param Result $resultPrototype
-     * @return Sqlsrv Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/Sqlsrv/Statement.php
+++ b/src/Adapter/Driver/Sqlsrv/Statement.php
@@ -77,7 +77,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Sqlsrv $driver
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -87,7 +87,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -111,8 +111,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * (there will need to already be a bound param set if it applies to this query)
      *
      * @param resource $resource
+     * @return Statement Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Statement
      */
     public function initialize($resource)
     {
@@ -134,7 +134,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -152,7 +152,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param $resource
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -172,7 +172,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return Statement
+     * @return Statement Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -193,8 +193,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * @param string $sql
      * @param array $options
+     * @return Statement Provides a fluent interface
      * @throws Exception\RuntimeException
-     * @return Statement
      */
     public function prepare($sql = null, array $options = [])
     {

--- a/src/Adapter/Driver/Sqlsrv/Statement.php
+++ b/src/Adapter/Driver/Sqlsrv/Statement.php
@@ -77,7 +77,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Sqlsrv $driver
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -87,7 +87,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param Profiler\ProfilerInterface $profiler
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -111,7 +111,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * (there will need to already be a bound param set if it applies to this query)
      *
      * @param resource $resource
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($resource)
@@ -134,7 +134,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set parameter container
      *
      * @param ParameterContainer $parameterContainer
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -152,7 +152,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param $resource
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -172,7 +172,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -193,7 +193,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * @param string $sql
      * @param array $options
-     * @return Statement Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function prepare($sql = null, array $options = [])

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -141,7 +141,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Offset unset
      *
      * @param  string $name
-     * @return ParameterContainer
+     * @return ParameterContainer Provides a fluent interface
      */
     public function offsetUnset($name)
     {
@@ -156,7 +156,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Set from array
      *
      * @param  array $data
-     * @return ParameterContainer
+     * @return ParameterContainer Provides a fluent interface
      */
     public function setFromArray(array $data)
     {
@@ -392,8 +392,8 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
 
     /**
      * @param array|ParameterContainer $parameters
+     * @return ParameterContainer Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return ParameterContainer
      */
     public function merge($parameters)
     {

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -141,7 +141,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Offset unset
      *
      * @param  string $name
-     * @return ParameterContainer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function offsetUnset($name)
     {
@@ -156,7 +156,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Set from array
      *
      * @param  array $data
-     * @return ParameterContainer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setFromArray(array $data)
     {
@@ -392,7 +392,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
 
     /**
      * @param array|ParameterContainer $parameters
-     * @return ParameterContainer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function merge($parameters)

--- a/src/Adapter/Platform/Mysql.php
+++ b/src/Adapter/Platform/Mysql.php
@@ -43,7 +43,7 @@ class Mysql extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Mysqli\Mysqli|\Zend\Db\Adapter\Driver\Pdo\Pdo|\mysqli|\PDO $driver
-     * @return Mysql Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Mysql.php
+++ b/src/Adapter/Platform/Mysql.php
@@ -43,9 +43,8 @@ class Mysql extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Mysqli\Mysqli|\Zend\Db\Adapter\Driver\Pdo\Pdo|\mysqli|\PDO $driver
+     * @return Mysql Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     *
-     * @return self
      */
     public function setDriver($driver)
     {

--- a/src/Adapter/Platform/Oracle.php
+++ b/src/Adapter/Platform/Oracle.php
@@ -41,8 +41,8 @@ class Oracle extends AbstractPlatform
 
     /**
      * @param Pdo|Oci8 $driver
+     * @return Oracle Provides a fluent interface
      * @throws InvalidArgumentException
-     * @return $this
      */
     public function setDriver($driver)
     {

--- a/src/Adapter/Platform/Oracle.php
+++ b/src/Adapter/Platform/Oracle.php
@@ -41,7 +41,7 @@ class Oracle extends AbstractPlatform
 
     /**
      * @param Pdo|Oci8 $driver
-     * @return Oracle Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -40,8 +40,8 @@ class Postgresql extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Pgsql\Pgsql|\Zend\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
+     * @return Postgresql Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return $this
      */
     public function setDriver($driver)
     {

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -40,7 +40,7 @@ class Postgresql extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Pgsql\Pgsql|\Zend\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
-     * @return Postgresql Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/SqlServer.php
+++ b/src/Adapter/Platform/SqlServer.php
@@ -42,9 +42,8 @@ class SqlServer extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Sqlsrv\Sqlsrv|\Zend\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
+     * @return SqlServer Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     *
-     * @return self
      */
     public function setDriver($driver)
     {

--- a/src/Adapter/Platform/SqlServer.php
+++ b/src/Adapter/Platform/SqlServer.php
@@ -42,7 +42,7 @@ class SqlServer extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Sqlsrv\Sqlsrv|\Zend\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
-     * @return SqlServer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Sqlite.php
+++ b/src/Adapter/Platform/Sqlite.php
@@ -42,7 +42,7 @@ class Sqlite extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Pdo\Pdo|\PDO $driver
-     * @return Sqlite Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Sqlite.php
+++ b/src/Adapter/Platform/Sqlite.php
@@ -42,9 +42,8 @@ class Sqlite extends AbstractPlatform
 
     /**
      * @param \Zend\Db\Adapter\Driver\Pdo\Pdo|\PDO $driver
+     * @return Sqlite Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     *
-     * @return self
      */
     public function setDriver($driver)
     {

--- a/src/Adapter/Profiler/Profiler.php
+++ b/src/Adapter/Profiler/Profiler.php
@@ -26,8 +26,8 @@ class Profiler implements ProfilerInterface
 
     /**
      * @param string|StatementContainerInterface $target
+     * @return Profiler Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
-     * @return Profiler
      */
     public function profilerStart($target)
     {
@@ -53,7 +53,7 @@ class Profiler implements ProfilerInterface
     }
 
     /**
-     * @return Profiler
+     * @return Profiler Provides a fluent interface
      */
     public function profilerFinish()
     {

--- a/src/Adapter/Profiler/Profiler.php
+++ b/src/Adapter/Profiler/Profiler.php
@@ -26,7 +26,7 @@ class Profiler implements ProfilerInterface
 
     /**
      * @param string|StatementContainerInterface $target
-     * @return Profiler Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function profilerStart($target)
@@ -53,7 +53,7 @@ class Profiler implements ProfilerInterface
     }
 
     /**
-     * @return Profiler Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function profilerFinish()
     {

--- a/src/Adapter/StatementContainer.php
+++ b/src/Adapter/StatementContainer.php
@@ -35,7 +35,7 @@ class StatementContainer implements StatementContainerInterface
 
     /**
      * @param $sql
-     * @return StatementContainer
+     * @return StatementContainer Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -53,7 +53,7 @@ class StatementContainer implements StatementContainerInterface
 
     /**
      * @param ParameterContainer $parameterContainer
-     * @return StatementContainer
+     * @return StatementContainer Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/StatementContainer.php
+++ b/src/Adapter/StatementContainer.php
@@ -35,7 +35,7 @@ class StatementContainer implements StatementContainerInterface
 
     /**
      * @param $sql
-     * @return StatementContainer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -53,7 +53,7 @@ class StatementContainer implements StatementContainerInterface
 
     /**
      * @param ParameterContainer $parameterContainer
-     * @return StatementContainer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -137,7 +137,7 @@ class ColumnObject
      * Set table name
      *
      * @param string $tableName
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -175,7 +175,7 @@ class ColumnObject
 
     /**
      * @param int $ordinalPosition to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -193,7 +193,7 @@ class ColumnObject
 
     /**
      * @param mixed $columnDefault to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setColumnDefault($columnDefault)
     {
@@ -211,7 +211,7 @@ class ColumnObject
 
     /**
      * @param bool $isNullable to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIsNullable($isNullable)
     {
@@ -237,7 +237,7 @@ class ColumnObject
 
     /**
      * @param string $dataType the $dataType to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDataType($dataType)
     {
@@ -255,7 +255,7 @@ class ColumnObject
 
     /**
      * @param int $characterMaximumLength the $characterMaximumLength to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setCharacterMaximumLength($characterMaximumLength)
     {
@@ -273,7 +273,7 @@ class ColumnObject
 
     /**
      * @param int $characterOctetLength the $characterOctetLength to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setCharacterOctetLength($characterOctetLength)
     {
@@ -291,7 +291,7 @@ class ColumnObject
 
     /**
      * @param int $numericPrecision the $numericPrevision to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setNumericPrecision($numericPrecision)
     {
@@ -309,7 +309,7 @@ class ColumnObject
 
     /**
      * @param int $numericScale the $numericScale to set
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setNumericScale($numericScale)
     {
@@ -327,7 +327,7 @@ class ColumnObject
 
     /**
      * @param  bool $numericUnsigned
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setNumericUnsigned($numericUnsigned)
     {
@@ -353,7 +353,7 @@ class ColumnObject
 
     /**
      * @param array $erratas
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setErratas(array $erratas)
     {
@@ -378,7 +378,7 @@ class ColumnObject
     /**
      * @param string $errataName
      * @param mixed $errataValue
-     * @return ColumnObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setErrata($errataName, $errataValue)
     {

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -137,7 +137,7 @@ class ColumnObject
      * Set table name
      *
      * @param string $tableName
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -175,7 +175,7 @@ class ColumnObject
 
     /**
      * @param int $ordinalPosition to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -193,7 +193,7 @@ class ColumnObject
 
     /**
      * @param mixed $columnDefault to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setColumnDefault($columnDefault)
     {
@@ -211,7 +211,7 @@ class ColumnObject
 
     /**
      * @param bool $isNullable to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setIsNullable($isNullable)
     {
@@ -237,7 +237,7 @@ class ColumnObject
 
     /**
      * @param string $dataType the $dataType to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setDataType($dataType)
     {
@@ -255,7 +255,7 @@ class ColumnObject
 
     /**
      * @param int $characterMaximumLength the $characterMaximumLength to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setCharacterMaximumLength($characterMaximumLength)
     {
@@ -273,7 +273,7 @@ class ColumnObject
 
     /**
      * @param int $characterOctetLength the $characterOctetLength to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setCharacterOctetLength($characterOctetLength)
     {
@@ -291,7 +291,7 @@ class ColumnObject
 
     /**
      * @param int $numericPrecision the $numericPrevision to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setNumericPrecision($numericPrecision)
     {
@@ -309,7 +309,7 @@ class ColumnObject
 
     /**
      * @param int $numericScale the $numericScale to set
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setNumericScale($numericScale)
     {
@@ -327,7 +327,7 @@ class ColumnObject
 
     /**
      * @param  bool $numericUnsigned
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setNumericUnsigned($numericUnsigned)
     {
@@ -353,7 +353,7 @@ class ColumnObject
 
     /**
      * @param array $erratas
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setErratas(array $erratas)
     {
@@ -378,7 +378,7 @@ class ColumnObject
     /**
      * @param string $errataName
      * @param mixed $errataValue
-     * @return ColumnObject
+     * @return ColumnObject Provides a fluent interface
      */
     public function setErrata($errataName, $errataValue)
     {

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -89,7 +89,7 @@ class ConstraintKeyObject
      * Set column name
      *
      * @param  string $columnName
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setColumnName($columnName)
     {
@@ -111,7 +111,7 @@ class ConstraintKeyObject
      * Set ordinal position
      *
      * @param  int $ordinalPosition
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -133,7 +133,7 @@ class ConstraintKeyObject
      * Set position in unique constraint
      *
      * @param  bool $positionInUniqueConstraint
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setPositionInUniqueConstraint($positionInUniqueConstraint)
     {
@@ -155,7 +155,7 @@ class ConstraintKeyObject
      * Set referenced table schema
      *
      * @param string $referencedTableSchema
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -177,7 +177,7 @@ class ConstraintKeyObject
      * Set Referenced table name
      *
      * @param  string $referencedTableName
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -199,7 +199,7 @@ class ConstraintKeyObject
      * Set referenced column name
      *
      * @param  string $referencedColumnName
-     * @return ConstraintKeyObject
+     * @return ConstraintKeyObject Provides a fluent interface
      */
     public function setReferencedColumnName($referencedColumnName)
     {

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -89,7 +89,7 @@ class ConstraintKeyObject
      * Set column name
      *
      * @param  string $columnName
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setColumnName($columnName)
     {
@@ -111,7 +111,7 @@ class ConstraintKeyObject
      * Set ordinal position
      *
      * @param  int $ordinalPosition
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -133,7 +133,7 @@ class ConstraintKeyObject
      * Set position in unique constraint
      *
      * @param  bool $positionInUniqueConstraint
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setPositionInUniqueConstraint($positionInUniqueConstraint)
     {
@@ -155,7 +155,7 @@ class ConstraintKeyObject
      * Set referenced table schema
      *
      * @param string $referencedTableSchema
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -177,7 +177,7 @@ class ConstraintKeyObject
      * Set Referenced table name
      *
      * @param  string $referencedTableName
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -199,7 +199,7 @@ class ConstraintKeyObject
      * Set referenced column name
      *
      * @param  string $referencedColumnName
-     * @return ConstraintKeyObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedColumnName($referencedColumnName)
     {

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -160,7 +160,7 @@ class ConstraintObject
      * Set table name
      *
      * @param  string $tableName
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -207,7 +207,7 @@ class ConstraintObject
      * Set Columns.
      *
      * @param string[] $columns
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setColumns(array $columns)
     {
@@ -229,7 +229,7 @@ class ConstraintObject
      * Set Referenced Table Schema.
      *
      * @param string $referencedTableSchema
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -251,7 +251,7 @@ class ConstraintObject
      * Set Referenced Table Name.
      *
      * @param string $referencedTableName
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -273,7 +273,7 @@ class ConstraintObject
      * Set Referenced Columns.
      *
      * @param string[] $referencedColumns
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setReferencedColumns(array $referencedColumns)
     {
@@ -295,7 +295,7 @@ class ConstraintObject
      * Set Match Option.
      *
      * @param string $matchOption
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setMatchOption($matchOption)
     {
@@ -317,7 +317,7 @@ class ConstraintObject
      * Set Update Rule.
      *
      * @param string $updateRule
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setUpdateRule($updateRule)
     {
@@ -339,7 +339,7 @@ class ConstraintObject
      * Set Delete Rule.
      *
      * @param string $deleteRule
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setDeleteRule($deleteRule)
     {
@@ -361,7 +361,7 @@ class ConstraintObject
      * Set Check Clause.
      *
      * @param string $checkClause
-     * @return ConstraintObject
+     * @return ConstraintObject Provides a fluent interface
      */
     public function setCheckClause($checkClause)
     {

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -160,7 +160,7 @@ class ConstraintObject
      * Set table name
      *
      * @param  string $tableName
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -207,7 +207,7 @@ class ConstraintObject
      * Set Columns.
      *
      * @param string[] $columns
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setColumns(array $columns)
     {
@@ -229,7 +229,7 @@ class ConstraintObject
      * Set Referenced Table Schema.
      *
      * @param string $referencedTableSchema
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -251,7 +251,7 @@ class ConstraintObject
      * Set Referenced Table Name.
      *
      * @param string $referencedTableName
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -273,7 +273,7 @@ class ConstraintObject
      * Set Referenced Columns.
      *
      * @param string[] $referencedColumns
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferencedColumns(array $referencedColumns)
     {
@@ -295,7 +295,7 @@ class ConstraintObject
      * Set Match Option.
      *
      * @param string $matchOption
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setMatchOption($matchOption)
     {
@@ -317,7 +317,7 @@ class ConstraintObject
      * Set Update Rule.
      *
      * @param string $updateRule
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setUpdateRule($updateRule)
     {
@@ -339,7 +339,7 @@ class ConstraintObject
      * Set Delete Rule.
      *
      * @param string $deleteRule
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDeleteRule($deleteRule)
     {
@@ -361,7 +361,7 @@ class ConstraintObject
      * Set Check Clause.
      *
      * @param string $checkClause
-     * @return ConstraintObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setCheckClause($checkClause)
     {

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -130,7 +130,7 @@ class TriggerObject
      * Set Name.
      *
      * @param string $name
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setName($name)
     {
@@ -152,7 +152,7 @@ class TriggerObject
      * Set Event Manipulation.
      *
      * @param string $eventManipulation
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setEventManipulation($eventManipulation)
     {
@@ -174,7 +174,7 @@ class TriggerObject
      * Set Event Object Catalog.
      *
      * @param string $eventObjectCatalog
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setEventObjectCatalog($eventObjectCatalog)
     {
@@ -196,7 +196,7 @@ class TriggerObject
      * Set Event Object Schema.
      *
      * @param string $eventObjectSchema
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setEventObjectSchema($eventObjectSchema)
     {
@@ -218,7 +218,7 @@ class TriggerObject
      * Set Event Object Table.
      *
      * @param string $eventObjectTable
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setEventObjectTable($eventObjectTable)
     {
@@ -240,7 +240,7 @@ class TriggerObject
      * Set Action Order.
      *
      * @param string $actionOrder
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionOrder($actionOrder)
     {
@@ -262,7 +262,7 @@ class TriggerObject
      * Set Action Condition.
      *
      * @param string $actionCondition
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionCondition($actionCondition)
     {
@@ -284,7 +284,7 @@ class TriggerObject
      * Set Action Statement.
      *
      * @param string $actionStatement
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionStatement($actionStatement)
     {
@@ -306,7 +306,7 @@ class TriggerObject
      * Set Action Orientation.
      *
      * @param string $actionOrientation
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionOrientation($actionOrientation)
     {
@@ -328,7 +328,7 @@ class TriggerObject
      * Set Action Timing.
      *
      * @param string $actionTiming
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionTiming($actionTiming)
     {
@@ -350,7 +350,7 @@ class TriggerObject
      * Set Action Reference Old Table.
      *
      * @param string $actionReferenceOldTable
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionReferenceOldTable($actionReferenceOldTable)
     {
@@ -372,7 +372,7 @@ class TriggerObject
      * Set Action Reference New Table.
      *
      * @param string $actionReferenceNewTable
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionReferenceNewTable($actionReferenceNewTable)
     {
@@ -394,7 +394,7 @@ class TriggerObject
      * Set Action Reference Old Row.
      *
      * @param string $actionReferenceOldRow
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionReferenceOldRow($actionReferenceOldRow)
     {
@@ -416,7 +416,7 @@ class TriggerObject
      * Set Action Reference New Row.
      *
      * @param string $actionReferenceNewRow
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setActionReferenceNewRow($actionReferenceNewRow)
     {
@@ -438,7 +438,7 @@ class TriggerObject
      * Set Created.
      *
      * @param \DateTime $created
-     * @return TriggerObject
+     * @return TriggerObject Provides a fluent interface
      */
     public function setCreated($created)
     {

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -130,7 +130,7 @@ class TriggerObject
      * Set Name.
      *
      * @param string $name
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setName($name)
     {
@@ -152,7 +152,7 @@ class TriggerObject
      * Set Event Manipulation.
      *
      * @param string $eventManipulation
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setEventManipulation($eventManipulation)
     {
@@ -174,7 +174,7 @@ class TriggerObject
      * Set Event Object Catalog.
      *
      * @param string $eventObjectCatalog
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setEventObjectCatalog($eventObjectCatalog)
     {
@@ -196,7 +196,7 @@ class TriggerObject
      * Set Event Object Schema.
      *
      * @param string $eventObjectSchema
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setEventObjectSchema($eventObjectSchema)
     {
@@ -218,7 +218,7 @@ class TriggerObject
      * Set Event Object Table.
      *
      * @param string $eventObjectTable
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setEventObjectTable($eventObjectTable)
     {
@@ -240,7 +240,7 @@ class TriggerObject
      * Set Action Order.
      *
      * @param string $actionOrder
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionOrder($actionOrder)
     {
@@ -262,7 +262,7 @@ class TriggerObject
      * Set Action Condition.
      *
      * @param string $actionCondition
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionCondition($actionCondition)
     {
@@ -284,7 +284,7 @@ class TriggerObject
      * Set Action Statement.
      *
      * @param string $actionStatement
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionStatement($actionStatement)
     {
@@ -306,7 +306,7 @@ class TriggerObject
      * Set Action Orientation.
      *
      * @param string $actionOrientation
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionOrientation($actionOrientation)
     {
@@ -328,7 +328,7 @@ class TriggerObject
      * Set Action Timing.
      *
      * @param string $actionTiming
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionTiming($actionTiming)
     {
@@ -350,7 +350,7 @@ class TriggerObject
      * Set Action Reference Old Table.
      *
      * @param string $actionReferenceOldTable
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionReferenceOldTable($actionReferenceOldTable)
     {
@@ -372,7 +372,7 @@ class TriggerObject
      * Set Action Reference New Table.
      *
      * @param string $actionReferenceNewTable
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionReferenceNewTable($actionReferenceNewTable)
     {
@@ -394,7 +394,7 @@ class TriggerObject
      * Set Action Reference Old Row.
      *
      * @param string $actionReferenceOldRow
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionReferenceOldRow($actionReferenceOldRow)
     {
@@ -416,7 +416,7 @@ class TriggerObject
      * Set Action Reference New Row.
      *
      * @param string $actionReferenceNewRow
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setActionReferenceNewRow($actionReferenceNewRow)
     {
@@ -438,7 +438,7 @@ class TriggerObject
      * Set Created.
      *
      * @param \DateTime $created
-     * @return TriggerObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setCreated($created)
     {

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -25,7 +25,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $viewDefinition to set
-     * @return ViewObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setViewDefinition($viewDefinition)
     {
@@ -43,7 +43,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $checkOption to set
-     * @return ViewObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setCheckOption($checkOption)
     {
@@ -61,7 +61,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param bool $isUpdatable to set
-     * @return ViewObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIsUpdatable($isUpdatable)
     {

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -25,7 +25,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $viewDefinition to set
-     * @return ViewObject
+     * @return ViewObject Provides a fluent interface
      */
     public function setViewDefinition($viewDefinition)
     {
@@ -43,7 +43,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $checkOption to set
-     * @return ViewObject
+     * @return ViewObject Provides a fluent interface
      */
     public function setCheckOption($checkOption)
     {
@@ -61,7 +61,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param bool $isUpdatable to set
-     * @return ViewObject
+     * @return ViewObject Provides a fluent interface
      */
     public function setIsUpdatable($isUpdatable)
     {

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -51,7 +51,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * Set the data source for the result set
      *
      * @param  array|Iterator|IteratorAggregate|ResultInterface $dataSource
-     * @return ResultSet
+     * @return AbstractResultSet Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($dataSource)
@@ -91,6 +91,10 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return $this;
     }
 
+    /**
+     * @return AbstractResultSet Provides a fluent interface
+     * @throws Exception\RuntimeException
+     */
     public function buffer()
     {
         if ($this->buffer === -2) {

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -51,7 +51,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * Set the data source for the result set
      *
      * @param  array|Iterator|IteratorAggregate|ResultInterface $dataSource
-     * @return AbstractResultSet Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($dataSource)
@@ -92,7 +92,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     }
 
     /**
-     * @return AbstractResultSet Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function buffer()

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -41,7 +41,7 @@ class HydratingResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  object $objectPrototype
-     * @return HydratingResultSet Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setObjectPrototype($objectPrototype)
@@ -69,7 +69,7 @@ class HydratingResultSet extends AbstractResultSet
      * Set the hydrator to use for each row object
      *
      * @param HydratorInterface $hydrator
-     * @return HydratingResultSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setHydrator(HydratorInterface $hydrator)
     {

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -41,8 +41,8 @@ class HydratingResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  object $objectPrototype
+     * @return HydratingResultSet Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return ResultSet
      */
     public function setObjectPrototype($objectPrototype)
     {
@@ -69,7 +69,7 @@ class HydratingResultSet extends AbstractResultSet
      * Set the hydrator to use for each row object
      *
      * @param HydratorInterface $hydrator
-     * @return HydratingResultSet
+     * @return HydratingResultSet Provides a fluent interface
      */
     public function setHydrator(HydratorInterface $hydrator)
     {

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -56,7 +56,7 @@ class ResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  ArrayObject $arrayObjectPrototype
-     * @return ResultSet Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setArrayObjectPrototype($arrayObjectPrototype)

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -56,8 +56,8 @@ class ResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  ArrayObject $arrayObjectPrototype
+     * @return ResultSet Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return ResultSet
      */
     public function setArrayObjectPrototype($arrayObjectPrototype)
     {

--- a/src/RowGateway/AbstractRowGateway.php
+++ b/src/RowGateway/AbstractRowGateway.php
@@ -91,7 +91,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  array $rowData
      * @param  bool  $rowExistsInDatabase
-     * @return AbstractRowGateway Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function populate(array $rowData, $rowExistsInDatabase = false)
     {
@@ -248,7 +248,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  string $offset
      * @param  mixed $value
-     * @return AbstractRowGateway Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function offsetSet($offset, $value)
     {
@@ -260,7 +260,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      * Offset unset
      *
      * @param  string $offset
-     * @return AbstractRowGateway Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function offsetUnset($offset)
     {

--- a/src/RowGateway/AbstractRowGateway.php
+++ b/src/RowGateway/AbstractRowGateway.php
@@ -91,7 +91,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  array $rowData
      * @param  bool  $rowExistsInDatabase
-     * @return AbstractRowGateway
+     * @return AbstractRowGateway Provides a fluent interface
      */
     public function populate(array $rowData, $rowExistsInDatabase = false)
     {
@@ -248,7 +248,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  string $offset
      * @param  mixed $value
-     * @return RowGateway
+     * @return AbstractRowGateway Provides a fluent interface
      */
     public function offsetSet($offset, $value)
     {
@@ -260,7 +260,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      * Offset unset
      *
      * @param  string $offset
-     * @return AbstractRowGateway
+     * @return AbstractRowGateway Provides a fluent interface
      */
     public function offsetUnset($offset)
     {

--- a/src/RowGateway/Feature/FeatureSet.php
+++ b/src/RowGateway/Feature/FeatureSet.php
@@ -42,7 +42,7 @@ class FeatureSet
 
     /**
      * @param AbstractRowGateway $rowGateway
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setRowGateway(AbstractRowGateway $rowGateway)
     {
@@ -67,7 +67,7 @@ class FeatureSet
 
     /**
      * @param array $features
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeatures(array $features)
     {
@@ -79,7 +79,7 @@ class FeatureSet
 
     /**
      * @param AbstractFeature $feature
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeature(AbstractFeature $feature)
     {

--- a/src/RowGateway/Feature/FeatureSet.php
+++ b/src/RowGateway/Feature/FeatureSet.php
@@ -40,6 +40,10 @@ class FeatureSet
         }
     }
 
+    /**
+     * @param AbstractRowGateway $rowGateway
+     * @return FeatureSet Provides a fluent interface
+     */
     public function setRowGateway(AbstractRowGateway $rowGateway)
     {
         $this->rowGateway = $rowGateway;
@@ -61,6 +65,10 @@ class FeatureSet
         return $feature;
     }
 
+    /**
+     * @param array $features
+     * @return FeatureSet Provides a fluent interface
+     */
     public function addFeatures(array $features)
     {
         foreach ($features as $feature) {
@@ -69,6 +77,10 @@ class FeatureSet
         return $this;
     }
 
+    /**
+     * @param AbstractFeature $feature
+     * @return FeatureSet Provides a fluent interface
+     */
     public function addFeature(AbstractFeature $feature)
     {
         $this->features[] = $feature;

--- a/src/Sql/Combine.php
+++ b/src/Sql/Combine.php
@@ -55,7 +55,9 @@ class Combine extends AbstractPreparableSql
      * @param string $type
      * @param string $modifier
      *
-     * @return self
+     * @return Combine Provides a fluent interface
+     *
+     * @throws Exception\InvalidArgumentException
      */
     public function combine($select, $type = self::COMBINE_UNION, $modifier = '')
     {
@@ -158,7 +160,7 @@ class Combine extends AbstractPreparableSql
     }
 
     /**
-     * @return $this
+     * @return Combine Provides a fluent interface
      */
     public function alignColumns()
     {

--- a/src/Sql/Combine.php
+++ b/src/Sql/Combine.php
@@ -55,7 +55,7 @@ class Combine extends AbstractPreparableSql
      * @param string $type
      * @param string $modifier
      *
-     * @return Combine Provides a fluent interface
+     * @return self Provides a fluent interface
      *
      * @throws Exception\InvalidArgumentException
      */
@@ -160,7 +160,7 @@ class Combine extends AbstractPreparableSql
     }
 
     /**
-     * @return Combine Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function alignColumns()
     {

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -94,7 +94,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -105,7 +105,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Column\ColumnInterface $column
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -117,7 +117,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     /**
      * @param  string $name
      * @param  Column\ColumnInterface $column
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function changeColumn($name, Column\ColumnInterface $column)
     {
@@ -128,7 +128,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function dropColumn($name)
     {
@@ -139,7 +139,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function dropConstraint($name)
     {
@@ -150,7 +150,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Constraint\ConstraintInterface $constraint
-     * @return self
+     * @return AlterTable Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -94,7 +94,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -105,7 +105,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Column\ColumnInterface $column
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -117,7 +117,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     /**
      * @param  string $name
      * @param  Column\ColumnInterface $column
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function changeColumn($name, Column\ColumnInterface $column)
     {
@@ -128,7 +128,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function dropColumn($name)
     {
@@ -139,7 +139,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function dropConstraint($name)
     {
@@ -150,7 +150,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Constraint\ConstraintInterface $constraint
-     * @return AlterTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/Column/AbstractLengthColumn.php
+++ b/src/Sql/Ddl/Column/AbstractLengthColumn.php
@@ -30,7 +30,7 @@ abstract class AbstractLengthColumn extends Column
 
     /**
      * @param  int $length
-     * @return AbstractLengthColumn Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setLength($length)
     {

--- a/src/Sql/Ddl/Column/AbstractLengthColumn.php
+++ b/src/Sql/Ddl/Column/AbstractLengthColumn.php
@@ -30,8 +30,7 @@ abstract class AbstractLengthColumn extends Column
 
     /**
      * @param  int $length
-     *
-     * @return self
+     * @return AbstractLengthColumn Provides a fluent interface
      */
     public function setLength($length)
     {

--- a/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
+++ b/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
@@ -49,7 +49,7 @@ abstract class AbstractPrecisionColumn extends AbstractLengthColumn
 
     /**
      * @param int|null $decimal
-     * @return self
+     * @return AbstractPrecisionColumn Provides a fluent interface
      */
     public function setDecimal($decimal)
     {

--- a/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
+++ b/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
@@ -49,7 +49,7 @@ abstract class AbstractPrecisionColumn extends AbstractLengthColumn
 
     /**
      * @param int|null $decimal
-     * @return AbstractPrecisionColumn Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDecimal($decimal)
     {

--- a/src/Sql/Ddl/Column/Column.php
+++ b/src/Sql/Ddl/Column/Column.php
@@ -64,7 +64,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function setName($name)
     {
@@ -82,7 +82,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  bool $nullable
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function setNullable($nullable)
     {
@@ -100,7 +100,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  null|string|int $default
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function setDefault($default)
     {
@@ -118,7 +118,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  array $options
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function setOptions(array $options)
     {
@@ -129,7 +129,7 @@ class Column implements ColumnInterface
     /**
      * @param  string $name
      * @param  string $value
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function setOption($name, $value)
     {
@@ -148,7 +148,7 @@ class Column implements ColumnInterface
     /**
      * @param ConstraintInterface $constraint
      *
-     * @return self
+     * @return Column Provides a fluent interface
      */
     public function addConstraint(ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/Column/Column.php
+++ b/src/Sql/Ddl/Column/Column.php
@@ -64,7 +64,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  string $name
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setName($name)
     {
@@ -82,7 +82,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  bool $nullable
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setNullable($nullable)
     {
@@ -100,7 +100,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  null|string|int $default
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDefault($default)
     {
@@ -118,7 +118,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  array $options
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOptions(array $options)
     {
@@ -129,7 +129,7 @@ class Column implements ColumnInterface
     /**
      * @param  string $name
      * @param  string $value
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOption($name, $value)
     {
@@ -148,7 +148,7 @@ class Column implements ColumnInterface
     /**
      * @param ConstraintInterface $constraint
      *
-     * @return Column Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addConstraint(ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/Constraint/AbstractConstraint.php
+++ b/src/Sql/Ddl/Constraint/AbstractConstraint.php
@@ -51,7 +51,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return AbstractConstraint Provides a fluent interface
      */
     public function setName($name)
     {
@@ -69,7 +69,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  null|string|array $columns
-     * @return self
+     * @return AbstractConstraint Provides a fluent interface
      */
     public function setColumns($columns)
     {
@@ -80,7 +80,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $column
-     * @return self
+     * @return AbstractConstraint Provides a fluent interface
      */
     public function addColumn($column)
     {

--- a/src/Sql/Ddl/Constraint/AbstractConstraint.php
+++ b/src/Sql/Ddl/Constraint/AbstractConstraint.php
@@ -51,7 +51,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $name
-     * @return AbstractConstraint Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setName($name)
     {
@@ -69,7 +69,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  null|string|array $columns
-     * @return AbstractConstraint Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setColumns($columns)
     {
@@ -80,7 +80,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $column
-     * @return AbstractConstraint Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addColumn($column)
     {

--- a/src/Sql/Ddl/Constraint/ForeignKey.php
+++ b/src/Sql/Ddl/Constraint/ForeignKey.php
@@ -70,7 +70,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $referenceTable
-     * @return ForeignKey Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferenceTable($referenceTable)
     {
@@ -88,7 +88,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  null|string|array $referenceColumn
-     * @return ForeignKey Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReferenceColumn($referenceColumn)
     {
@@ -107,7 +107,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onDeleteRule
-     * @return ForeignKey Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOnDeleteRule($onDeleteRule)
     {
@@ -126,7 +126,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onUpdateRule
-     * @return ForeignKey Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOnUpdateRule($onUpdateRule)
     {

--- a/src/Sql/Ddl/Constraint/ForeignKey.php
+++ b/src/Sql/Ddl/Constraint/ForeignKey.php
@@ -70,7 +70,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $referenceTable
-     * @return self
+     * @return ForeignKey Provides a fluent interface
      */
     public function setReferenceTable($referenceTable)
     {
@@ -88,7 +88,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  null|string|array $referenceColumn
-     * @return self
+     * @return ForeignKey Provides a fluent interface
      */
     public function setReferenceColumn($referenceColumn)
     {
@@ -107,7 +107,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onDeleteRule
-     * @return self
+     * @return ForeignKey Provides a fluent interface
      */
     public function setOnDeleteRule($onDeleteRule)
     {
@@ -126,7 +126,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onUpdateRule
-     * @return self
+     * @return ForeignKey Provides a fluent interface
      */
     public function setOnUpdateRule($onUpdateRule)
     {

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -69,7 +69,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  bool $temporary
-     * @return self
+     * @return CreateTable Provides a fluent interface
      */
     public function setTemporary($temporary)
     {
@@ -87,7 +87,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self
+     * @return CreateTable Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -97,7 +97,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Column\ColumnInterface $column
-     * @return self
+     * @return CreateTable Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -107,7 +107,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Constraint\ConstraintInterface $constraint
-     * @return self
+     * @return CreateTable Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -69,7 +69,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  bool $temporary
-     * @return CreateTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTemporary($temporary)
     {
@@ -87,7 +87,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return CreateTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -97,7 +97,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Column\ColumnInterface $column
-     * @return CreateTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -107,7 +107,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  Constraint\ConstraintInterface $constraint
-     * @return CreateTable Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Delete.php
+++ b/src/Sql/Delete.php
@@ -71,7 +71,7 @@ class Delete extends AbstractPreparableSql
      * Create from statement
      *
      * @param  string|TableIdentifier $table
-     * @return Delete Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function from($table)
     {
@@ -101,7 +101,7 @@ class Delete extends AbstractPreparableSql
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      *
-     * @return Delete Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {

--- a/src/Sql/Delete.php
+++ b/src/Sql/Delete.php
@@ -71,7 +71,7 @@ class Delete extends AbstractPreparableSql
      * Create from statement
      *
      * @param  string|TableIdentifier $table
-     * @return Delete
+     * @return Delete Provides a fluent interface
      */
     public function from($table)
     {
@@ -101,7 +101,7 @@ class Delete extends AbstractPreparableSql
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      *
-     * @return Delete
+     * @return Delete Provides a fluent interface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {

--- a/src/Sql/Expression.php
+++ b/src/Sql/Expression.php
@@ -63,7 +63,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param $expression
-     * @return Expression Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setExpression($expression)
@@ -85,7 +85,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param $parameters
-     * @return Expression Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setParameters($parameters)
@@ -108,7 +108,7 @@ class Expression extends AbstractExpression
     /**
      * @deprecated
      * @param array $types
-     * @return Expression Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTypes(array $types)
     {

--- a/src/Sql/Expression.php
+++ b/src/Sql/Expression.php
@@ -63,7 +63,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param $expression
-     * @return Expression
+     * @return Expression Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setExpression($expression)
@@ -85,7 +85,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param $parameters
-     * @return Expression
+     * @return Expression Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setParameters($parameters)
@@ -108,7 +108,7 @@ class Expression extends AbstractExpression
     /**
      * @deprecated
      * @param array $types
-     * @return Expression
+     * @return Expression Provides a fluent interface
      */
     public function setTypes(array $types)
     {

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -61,7 +61,7 @@ class Insert extends AbstractPreparableSql
      * Create INTO clause
      *
      * @param  string|TableIdentifier $table
-     * @return Insert Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function into($table)
     {
@@ -73,7 +73,7 @@ class Insert extends AbstractPreparableSql
      * Specify columns
      *
      * @param  array $columns
-     * @return Insert Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function columns(array $columns)
     {
@@ -86,7 +86,7 @@ class Insert extends AbstractPreparableSql
      *
      * @param  array|Select $values
      * @param  string $flag one of VALUES_MERGE or VALUES_SET; defaults to VALUES_SET
-     * @return Insert Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function values($values, $flag = self::VALUES_SET)
@@ -224,7 +224,7 @@ class Insert extends AbstractPreparableSql
      *
      * @param  string $name
      * @param  mixed $value
-     * @return Insert Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function __set($name, $value)
     {

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -61,7 +61,7 @@ class Insert extends AbstractPreparableSql
      * Create INTO clause
      *
      * @param  string|TableIdentifier $table
-     * @return Insert
+     * @return Insert Provides a fluent interface
      */
     public function into($table)
     {
@@ -73,7 +73,7 @@ class Insert extends AbstractPreparableSql
      * Specify columns
      *
      * @param  array $columns
-     * @return Insert
+     * @return Insert Provides a fluent interface
      */
     public function columns(array $columns)
     {
@@ -86,8 +86,8 @@ class Insert extends AbstractPreparableSql
      *
      * @param  array|Select $values
      * @param  string $flag one of VALUES_MERGE or VALUES_SET; defaults to VALUES_SET
+     * @return Insert Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Insert
      */
     public function values($values, $flag = self::VALUES_SET)
     {
@@ -224,7 +224,7 @@ class Insert extends AbstractPreparableSql
      *
      * @param  string $name
      * @param  mixed $value
-     * @return Insert
+     * @return Insert Provides a fluent interface
      */
     public function __set($name, $value)
     {

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -115,7 +115,7 @@ class Join implements Iterator, Countable
      *     of column names, or (a) specification(s) such as SQL_STAR representing
      *     the columns to join.
      * @param string $type The JOIN type to use; see the JOIN_* constants.
-     * @return Join Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException for invalid $name values.
      */
     public function join($name, $on, $columns = [Select::SQL_STAR], $type = Join::JOIN_INNER)
@@ -143,7 +143,7 @@ class Join implements Iterator, Countable
     /**
      * Reset to an empty list of JOIN specifications.
      *
-     * @return Join Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function reset()
     {

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -115,7 +115,7 @@ class Join implements Iterator, Countable
      *     of column names, or (a) specification(s) such as SQL_STAR representing
      *     the columns to join.
      * @param string $type The JOIN type to use; see the JOIN_* constants.
-     * @return self Implements a fluent interface.
+     * @return Join Provides a fluent interface
      * @throws Exception\InvalidArgumentException for invalid $name values.
      */
     public function join($name, $on, $columns = [Select::SQL_STAR], $type = Join::JOIN_INNER)
@@ -143,7 +143,7 @@ class Join implements Iterator, Countable
     /**
      * Reset to an empty list of JOIN specifications.
      *
-     * @return self Implements a fluent interface.
+     * @return Join Provides a fluent interface
      */
     public function reset()
     {

--- a/src/Sql/Literal.php
+++ b/src/Sql/Literal.php
@@ -26,7 +26,7 @@ class Literal implements ExpressionInterface
 
     /**
      * @param string $literal
-     * @return Literal Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setLiteral($literal)
     {

--- a/src/Sql/Literal.php
+++ b/src/Sql/Literal.php
@@ -26,7 +26,7 @@ class Literal implements ExpressionInterface
 
     /**
      * @param string $literal
-     * @return Literal
+     * @return Literal Provides a fluent interface
      */
     public function setLiteral($literal)
     {

--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -37,7 +37,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
 
     /**
      * @param AlterTable $subject
-     * @return \Zend\Db\Sql\Platform\PlatformDecoratorInterface
+     * @return AlterTableDecorator Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -37,7 +37,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
 
     /**
      * @param AlterTable $subject
-     * @return AlterTableDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -38,7 +38,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     /**
      * @param CreateTable $subject
      *
-     * @return CreateTableDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -38,7 +38,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     /**
      * @param CreateTable $subject
      *
-     * @return self
+     * @return CreateTableDecorator Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -22,7 +22,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
 
     /**
      * @param CreateTable $subject
-     * @return CreateTableDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -22,7 +22,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
 
     /**
      * @param CreateTable $subject
-     * @return self
+     * @return CreateTableDecorator Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Sqlite/SelectDecorator.php
+++ b/src/Sql/Platform/Sqlite/SelectDecorator.php
@@ -26,7 +26,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      * Set Subject
      *
      * @param Select $select
-     * @return SelectDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($select)
     {

--- a/src/Sql/Platform/Sqlite/SelectDecorator.php
+++ b/src/Sql/Platform/Sqlite/SelectDecorator.php
@@ -26,7 +26,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      * Set Subject
      *
      * @param Select $select
-     * @return self
+     * @return SelectDecorator Provides a fluent interface
      */
     public function setSubject($select)
     {

--- a/src/Sql/Predicate/Between.php
+++ b/src/Sql/Predicate/Between.php
@@ -42,7 +42,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return Between
+     * @return Between Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -64,7 +64,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set minimum boundary for comparison
      *
      * @param  int|float|string $minValue
-     * @return Between
+     * @return Between Provides a fluent interface
      */
     public function setMinValue($minValue)
     {
@@ -86,7 +86,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set maximum boundary for comparison
      *
      * @param  int|float|string $maxValue
-     * @return Between
+     * @return Between Provides a fluent interface
      */
     public function setMaxValue($maxValue)
     {
@@ -108,7 +108,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return Between
+     * @return Between Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Between.php
+++ b/src/Sql/Predicate/Between.php
@@ -42,7 +42,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return Between Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -64,7 +64,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set minimum boundary for comparison
      *
      * @param  int|float|string $minValue
-     * @return Between Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setMinValue($minValue)
     {
@@ -86,7 +86,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set maximum boundary for comparison
      *
      * @param  int|float|string $maxValue
-     * @return Between Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setMaxValue($maxValue)
     {
@@ -108,7 +108,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return Between Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -42,7 +42,7 @@ class In extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string|array $identifier
-     * @return In
+     * @return In Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -65,8 +65,8 @@ class In extends AbstractExpression implements PredicateInterface
      * Set set of values for IN comparison
      *
      * @param  array|Select                       $valueSet
+     * @return In Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return In
      */
     public function setValueSet($valueSet)
     {

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -42,7 +42,7 @@ class In extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string|array $identifier
-     * @return In Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -65,7 +65,7 @@ class In extends AbstractExpression implements PredicateInterface
      * Set set of values for IN comparison
      *
      * @param  array|Select                       $valueSet
-     * @return In Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setValueSet($valueSet)

--- a/src/Sql/Predicate/IsNull.php
+++ b/src/Sql/Predicate/IsNull.php
@@ -39,7 +39,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return IsNull
+     * @return IsNull Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -61,7 +61,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return IsNull
+     * @return IsNull Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/IsNull.php
+++ b/src/Sql/Predicate/IsNull.php
@@ -39,7 +39,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return IsNull Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -61,7 +61,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return IsNull Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Like.php
+++ b/src/Sql/Predicate/Like.php
@@ -44,7 +44,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $identifier
-     * @return Like Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -62,7 +62,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $like
-     * @return Like Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setLike($like)
     {
@@ -80,7 +80,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $specification
-     * @return Like Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Like.php
+++ b/src/Sql/Predicate/Like.php
@@ -44,7 +44,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $identifier
-     * @return self
+     * @return Like Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -62,7 +62,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $like
-     * @return self
+     * @return Like Provides a fluent interface
      */
     public function setLike($like)
     {
@@ -80,7 +80,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $specification
-     * @return self
+     * @return Like Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Operator.php
+++ b/src/Sql/Predicate/Operator.php
@@ -107,7 +107,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  int|float|bool|string $left
      *
-     * @return Operator
+     * @return Operator Provides a fluent interface
      */
     public function setLeft($left)
     {
@@ -136,7 +136,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
      *
-     * @return Operator
+     * @return Operator Provides a fluent interface
      *
      * @throws Exception\InvalidArgumentException
      */
@@ -170,7 +170,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set operator string
      *
      * @param  string $operator
-     * @return Operator
+     * @return Operator Provides a fluent interface
      */
     public function setOperator($operator)
     {
@@ -194,7 +194,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  int|float|bool|string $right
      *
-     * @return Operator
+     * @return Operator Provides a fluent interface
      */
     public function setRight($right)
     {
@@ -222,8 +222,8 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set parameter type for right side of operator
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
+     * @return Operator Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Operator
      */
     public function setRightType($type)
     {

--- a/src/Sql/Predicate/Operator.php
+++ b/src/Sql/Predicate/Operator.php
@@ -107,7 +107,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  int|float|bool|string $left
      *
-     * @return Operator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setLeft($left)
     {
@@ -136,7 +136,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
      *
-     * @return Operator Provides a fluent interface
+     * @return self Provides a fluent interface
      *
      * @throws Exception\InvalidArgumentException
      */
@@ -170,7 +170,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set operator string
      *
      * @param  string $operator
-     * @return Operator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOperator($operator)
     {
@@ -194,7 +194,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      *
      * @param  int|float|bool|string $right
      *
-     * @return Operator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setRight($right)
     {
@@ -222,7 +222,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set parameter type for right side of operator
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
-     * @return Operator Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setRightType($type)

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -74,7 +74,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function equalTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -96,7 +96,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function notEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -118,7 +118,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function lessThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -140,7 +140,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function greaterThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -162,7 +162,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function lessThanOrEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -184,7 +184,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function greaterThanOrEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -204,7 +204,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  string $like
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function like($identifier, $like)
     {
@@ -223,7 +223,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  string $notLike
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function notLike($identifier, $notLike)
     {
@@ -240,7 +240,7 @@ class Predicate extends PredicateSet
      *
      * @param $expression
      * @param $parameters
-     * @return $this
+     * @return Predicate Provides a fluent interface
      */
     public function expression($expression, $parameters = null)
     {
@@ -259,7 +259,7 @@ class Predicate extends PredicateSet
      * Literal predicate, for parameters, use expression()
      *
      * @param  string $literal
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function literal($literal)
     {
@@ -289,7 +289,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNull predicate
      *
      * @param  string $identifier
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function isNull($identifier)
     {
@@ -308,7 +308,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNotNull predicate
      *
      * @param  string $identifier
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function isNotNull($identifier)
     {
@@ -328,7 +328,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  array|\Zend\Db\Sql\Select $valueSet
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function in($identifier, $valueSet = null)
     {
@@ -348,7 +348,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  array|\Zend\Db\Sql\Select $valueSet
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function notIn($identifier, $valueSet = null)
     {
@@ -369,7 +369,7 @@ class Predicate extends PredicateSet
      * @param  string $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function between($identifier, $minValue, $maxValue)
     {
@@ -390,7 +390,7 @@ class Predicate extends PredicateSet
      * @param  string $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function notBetween($identifier, $minValue, $maxValue)
     {
@@ -411,7 +411,7 @@ class Predicate extends PredicateSet
      * used fluently within where chains as any other concrete predicate.
      *
      * @param  PredicateInterface $predicate
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function predicate(PredicateInterface $predicate)
     {
@@ -430,7 +430,7 @@ class Predicate extends PredicateSet
      * Overloads "or", "and", "nest", and "unnest"
      *
      * @param  string $name
-     * @return Predicate
+     * @return Predicate Provides a fluent interface
      */
     public function __get($name)
     {

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -74,7 +74,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function equalTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -96,7 +96,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function notEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -118,7 +118,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function lessThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -140,7 +140,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function greaterThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -162,7 +162,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function lessThanOrEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -184,7 +184,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function greaterThanOrEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -204,7 +204,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  string $like
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function like($identifier, $like)
     {
@@ -223,7 +223,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  string $notLike
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function notLike($identifier, $notLike)
     {
@@ -240,7 +240,7 @@ class Predicate extends PredicateSet
      *
      * @param $expression
      * @param $parameters
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function expression($expression, $parameters = null)
     {
@@ -259,7 +259,7 @@ class Predicate extends PredicateSet
      * Literal predicate, for parameters, use expression()
      *
      * @param  string $literal
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function literal($literal)
     {
@@ -289,7 +289,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNull predicate
      *
      * @param  string $identifier
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function isNull($identifier)
     {
@@ -308,7 +308,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNotNull predicate
      *
      * @param  string $identifier
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function isNotNull($identifier)
     {
@@ -328,7 +328,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  array|\Zend\Db\Sql\Select $valueSet
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function in($identifier, $valueSet = null)
     {
@@ -348,7 +348,7 @@ class Predicate extends PredicateSet
      *
      * @param  string $identifier
      * @param  array|\Zend\Db\Sql\Select $valueSet
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function notIn($identifier, $valueSet = null)
     {
@@ -369,7 +369,7 @@ class Predicate extends PredicateSet
      * @param  string $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function between($identifier, $minValue, $maxValue)
     {
@@ -390,7 +390,7 @@ class Predicate extends PredicateSet
      * @param  string $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function notBetween($identifier, $minValue, $maxValue)
     {
@@ -411,7 +411,7 @@ class Predicate extends PredicateSet
      * used fluently within where chains as any other concrete predicate.
      *
      * @param  PredicateInterface $predicate
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function predicate(PredicateInterface $predicate)
     {
@@ -430,7 +430,7 @@ class Predicate extends PredicateSet
      * Overloads "or", "and", "nest", and "unnest"
      *
      * @param  string $name
-     * @return Predicate Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function __get($name)
     {

--- a/src/Sql/Predicate/PredicateSet.php
+++ b/src/Sql/Predicate/PredicateSet.php
@@ -44,7 +44,7 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param  PredicateInterface $predicate
      * @param  string $combination
-     * @return PredicateSet
+     * @return PredicateSet Provides a fluent interface
      */
     public function addPredicate(PredicateInterface $predicate, $combination = null)
     {
@@ -66,7 +66,8 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param PredicateInterface|\Closure|string|array $predicates
      * @param string $combination
-     * @return PredicateSet
+     * @return PredicateSet Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function addPredicates($predicates, $combination = self::OP_AND)
     {
@@ -138,7 +139,7 @@ class PredicateSet implements PredicateInterface, Countable
      * Add predicate using OR operator
      *
      * @param  PredicateInterface $predicate
-     * @return PredicateSet
+     * @return PredicateSet Provides a fluent interface
      */
     public function orPredicate(PredicateInterface $predicate)
     {
@@ -150,7 +151,7 @@ class PredicateSet implements PredicateInterface, Countable
      * Add predicate using AND operator
      *
      * @param  PredicateInterface $predicate
-     * @return PredicateSet
+     * @return PredicateSet Provides a fluent interface
      */
     public function andPredicate(PredicateInterface $predicate)
     {

--- a/src/Sql/Predicate/PredicateSet.php
+++ b/src/Sql/Predicate/PredicateSet.php
@@ -44,7 +44,7 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param  PredicateInterface $predicate
      * @param  string $combination
-     * @return PredicateSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addPredicate(PredicateInterface $predicate, $combination = null)
     {
@@ -66,7 +66,7 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param PredicateInterface|\Closure|string|array $predicates
      * @param string $combination
-     * @return PredicateSet Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addPredicates($predicates, $combination = self::OP_AND)
@@ -139,7 +139,7 @@ class PredicateSet implements PredicateInterface, Countable
      * Add predicate using OR operator
      *
      * @param  PredicateInterface $predicate
-     * @return PredicateSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function orPredicate(PredicateInterface $predicate)
     {
@@ -151,7 +151,7 @@ class PredicateSet implements PredicateInterface, Countable
      * Add predicate using AND operator
      *
      * @param  PredicateInterface $predicate
-     * @return PredicateSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function andPredicate(PredicateInterface $predicate)
     {

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -190,8 +190,8 @@ class Select extends AbstractPreparableSql
      * Create from clause
      *
      * @param  string|array|TableIdentifier $table
+     * @return Select Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Select
      */
     public function from($table)
     {
@@ -213,7 +213,8 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|Expression $quantifier DISTINCT|ALL
-     * @return Select
+     * @return Select Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function quantifier($quantifier)
     {
@@ -242,7 +243,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  array $columns
      * @param  bool  $prefixColumnsWithTable
-     * @return Select
+     * @return Select Provides a fluent interface
      */
     public function columns(array $columns, $prefixColumnsWithTable = true)
     {
@@ -258,8 +259,8 @@ class Select extends AbstractPreparableSql
      * @param  string $on
      * @param  string|array $columns
      * @param  string $type one of the JOIN_* constants
+     * @return Select Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Select
      */
     public function join($name, $on, $columns = self::SQL_STAR, $type = self::JOIN_INNER)
     {
@@ -273,8 +274,8 @@ class Select extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array|Predicate\PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
+     * @return Select Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Select
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
@@ -286,6 +287,10 @@ class Select extends AbstractPreparableSql
         return $this;
     }
 
+    /**
+     * @param mixed $group
+     * @return Select Provides a fluent interface
+     */
     public function group($group)
     {
         if (is_array($group)) {
@@ -303,7 +308,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return Select
+     * @return Select Provides a fluent interface
      */
     public function having($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
@@ -317,7 +322,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|array $order
-     * @return Select
+     * @return Select Provides a fluent interface
      */
     public function order($order)
     {
@@ -342,7 +347,8 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $limit
-     * @return Select
+     * @return Select Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function limit($limit)
     {
@@ -360,7 +366,8 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $offset
-     * @return Select
+     * @return Select Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function offset($offset)
     {
@@ -380,7 +387,7 @@ class Select extends AbstractPreparableSql
      * @param Select $select
      * @param string $type
      * @param string $modifier
-     * @return Select
+     * @return Select Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function combine(Select $select, $type = self::COMBINE_UNION, $modifier = '')
@@ -398,7 +405,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string $part
-     * @return Select
+     * @return Select Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function reset($part)
@@ -446,6 +453,11 @@ class Select extends AbstractPreparableSql
         return $this;
     }
 
+    /**
+     * @param $index
+     * @param $specification
+     * @return Select Provides a fluent interface
+     */
     public function setSpecification($index, $specification)
     {
         if (!method_exists($this, 'process' . $index)) {

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -190,7 +190,7 @@ class Select extends AbstractPreparableSql
      * Create from clause
      *
      * @param  string|array|TableIdentifier $table
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function from($table)
@@ -213,7 +213,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|Expression $quantifier DISTINCT|ALL
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function quantifier($quantifier)
@@ -243,7 +243,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  array $columns
      * @param  bool  $prefixColumnsWithTable
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function columns(array $columns, $prefixColumnsWithTable = true)
     {
@@ -259,7 +259,7 @@ class Select extends AbstractPreparableSql
      * @param  string $on
      * @param  string|array $columns
      * @param  string $type one of the JOIN_* constants
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function join($name, $on, $columns = self::SQL_STAR, $type = self::JOIN_INNER)
@@ -274,7 +274,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array|Predicate\PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
@@ -289,7 +289,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param mixed $group
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function group($group)
     {
@@ -308,7 +308,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function having($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
@@ -322,7 +322,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|array $order
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function order($order)
     {
@@ -347,7 +347,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $limit
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function limit($limit)
@@ -366,7 +366,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $offset
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function offset($offset)
@@ -387,7 +387,7 @@ class Select extends AbstractPreparableSql
      * @param Select $select
      * @param string $type
      * @param string $modifier
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function combine(Select $select, $type = self::COMBINE_UNION, $modifier = '')
@@ -405,7 +405,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string $part
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function reset($part)
@@ -456,7 +456,7 @@ class Select extends AbstractPreparableSql
     /**
      * @param $index
      * @param $specification
-     * @return Select Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSpecification($index, $specification)
     {

--- a/src/Sql/Sql.php
+++ b/src/Sql/Sql.php
@@ -51,6 +51,11 @@ class Sql
         return ($this->table !== null);
     }
 
+    /**
+     * @param string|array|TableIdentifier $table
+     * @return Sql Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
+     */
     public function setTable($table)
     {
         if (is_string($table) || is_array($table) || $table instanceof TableIdentifier) {

--- a/src/Sql/Sql.php
+++ b/src/Sql/Sql.php
@@ -53,7 +53,7 @@ class Sql
 
     /**
      * @param string|array|TableIdentifier $table
-     * @return Sql Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setTable($table)

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -88,7 +88,7 @@ class Update extends AbstractPreparableSql
      * Specify table for statement
      *
      * @param  string|TableIdentifier $table
-     * @return Update Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function table($table)
     {
@@ -101,7 +101,7 @@ class Update extends AbstractPreparableSql
      *
      * @param  array $values Associative array of key values
      * @param  string $flag One of the VALUES_* constants
-     * @return Update Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function set(array $values, $flag = self::VALUES_SET)
@@ -128,7 +128,7 @@ class Update extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return Update Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
@@ -147,7 +147,7 @@ class Update extends AbstractPreparableSql
      * @param  string|array $name
      * @param  string $on
      * @param  string $type one of the JOIN_* constants
-     * @return Update Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function join($name, $on, $type = Join::JOIN_INNER)

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -88,7 +88,7 @@ class Update extends AbstractPreparableSql
      * Specify table for statement
      *
      * @param  string|TableIdentifier $table
-     * @return Update
+     * @return Update Provides a fluent interface
      */
     public function table($table)
     {
@@ -101,8 +101,8 @@ class Update extends AbstractPreparableSql
      *
      * @param  array $values Associative array of key values
      * @param  string $flag One of the VALUES_* constants
+     * @return Update Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Update
      */
     public function set(array $values, $flag = self::VALUES_SET)
     {
@@ -128,8 +128,8 @@ class Update extends AbstractPreparableSql
      *
      * @param  Where|\Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
+     * @return Update Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Update
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
@@ -147,8 +147,8 @@ class Update extends AbstractPreparableSql
      * @param  string|array $name
      * @param  string $on
      * @param  string $type one of the JOIN_* constants
+     * @return Update Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Update
      */
     public function join($name, $on, $type = Join::JOIN_INNER)
     {

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -37,7 +37,7 @@ class FeatureSet
 
     /**
      * @param AbstractTableGateway $tableGateway
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTableGateway(AbstractTableGateway $tableGateway)
     {
@@ -62,7 +62,7 @@ class FeatureSet
 
     /**
      * @param array $features
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeatures(array $features)
     {
@@ -74,7 +74,7 @@ class FeatureSet
 
     /**
      * @param AbstractFeature $feature
-     * @return FeatureSet Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addFeature(AbstractFeature $feature)
     {

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -35,6 +35,10 @@ class FeatureSet
         }
     }
 
+    /**
+     * @param AbstractTableGateway $tableGateway
+     * @return FeatureSet Provides a fluent interface
+     */
     public function setTableGateway(AbstractTableGateway $tableGateway)
     {
         $this->tableGateway = $tableGateway;
@@ -56,6 +60,10 @@ class FeatureSet
         return $feature;
     }
 
+    /**
+     * @param array $features
+     * @return FeatureSet Provides a fluent interface
+     */
     public function addFeatures(array $features)
     {
         foreach ($features as $feature) {
@@ -64,6 +72,10 @@ class FeatureSet
         return $this;
     }
 
+    /**
+     * @param AbstractFeature $feature
+     * @return FeatureSet Provides a fluent interface
+     */
     public function addFeature(AbstractFeature $feature)
     {
         if ($this->tableGateway instanceof TableGatewayInterface) {

--- a/test/TestAsset/DeleteDecorator.php
+++ b/test/TestAsset/DeleteDecorator.php
@@ -15,6 +15,10 @@ class DeleteDecorator extends Sql\Delete implements Sql\Platform\PlatformDecorat
 {
     protected $subject = null;
 
+    /**
+     * @param $subject
+     * @return DeleteDecorator Provides a fluent interface
+     */
     public function setSubject($subject)
     {
         $this->subject = $subject;

--- a/test/TestAsset/DeleteDecorator.php
+++ b/test/TestAsset/DeleteDecorator.php
@@ -17,7 +17,7 @@ class DeleteDecorator extends Sql\Delete implements Sql\Platform\PlatformDecorat
 
     /**
      * @param $subject
-     * @return DeleteDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/TestAsset/InsertDecorator.php
+++ b/test/TestAsset/InsertDecorator.php
@@ -17,7 +17,7 @@ class InsertDecorator extends Sql\Insert implements Sql\Platform\PlatformDecorat
 
     /**
      * @param $subject
-     * @return InsertDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/TestAsset/InsertDecorator.php
+++ b/test/TestAsset/InsertDecorator.php
@@ -15,6 +15,10 @@ class InsertDecorator extends Sql\Insert implements Sql\Platform\PlatformDecorat
 {
     protected $subject = null;
 
+    /**
+     * @param $subject
+     * @return InsertDecorator Provides a fluent interface
+     */
     public function setSubject($subject)
     {
         $this->subject = $subject;

--- a/test/TestAsset/SelectDecorator.php
+++ b/test/TestAsset/SelectDecorator.php
@@ -17,7 +17,7 @@ class SelectDecorator extends Sql\Select implements Sql\Platform\PlatformDecorat
 
     /**
      * @param $subject
-     * @return SelectDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/TestAsset/SelectDecorator.php
+++ b/test/TestAsset/SelectDecorator.php
@@ -15,6 +15,10 @@ class SelectDecorator extends Sql\Select implements Sql\Platform\PlatformDecorat
 {
     protected $subject = null;
 
+    /**
+     * @param $subject
+     * @return SelectDecorator Provides a fluent interface
+     */
     public function setSubject($subject)
     {
         $this->subject = $subject;

--- a/test/TestAsset/UpdateDecorator.php
+++ b/test/TestAsset/UpdateDecorator.php
@@ -15,6 +15,10 @@ class UpdateDecorator extends Sql\Update implements Sql\Platform\PlatformDecorat
 {
     protected $subject = null;
 
+    /**
+     * @param $subject
+     * @return UpdateDecorator Provides a fluent interface
+     */
     public function setSubject($subject)
     {
         $this->subject = $subject;

--- a/test/TestAsset/UpdateDecorator.php
+++ b/test/TestAsset/UpdateDecorator.php
@@ -17,7 +17,7 @@ class UpdateDecorator extends Sql\Update implements Sql\Platform\PlatformDecorat
 
     /**
      * @param $subject
-     * @return UpdateDecorator Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setSubject($subject)
     {


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of $this and self keyword from the DocBlocks.