### PR TITLE
#186 [RFC][WIP] Sequence Support

### DIFF
--- a/doc/book/table-gateway.md
+++ b/doc/book/table-gateway.md
@@ -293,11 +293,12 @@ There are a number of features built-in and shipped with zend-db:
   to run an extra metadata query on every `TableGateway` object construction. If that is the case,
   take note of what PostgreSQL created using
   ```sql
-    SELECT 'column_default' FROM information_schema.columns WHERE
-    table_schema = 'public'
-    AND table_name = 'artist'
-    AND column_name = 'id'
-    AND column_default LIKE 'nextval%';
+    SELECT 'column_default'
+    FROM information_schema.columns 
+    WHERE table_schema = 'public'
+      AND table_name = 'artist'
+      AND column_name = 'id'
+      AND column_default LIKE 'nextval%';
   ```
   
   take note of what `nextval` is reading from, and add it to `SequenceFeature` constructor.

--- a/doc/book/table-gateway.md
+++ b/doc/book/table-gateway.md
@@ -286,19 +286,14 @@ There are a number of features built-in and shipped with zend-db:
   
   With second parameter left null, `TableGateway` will generate sequence name based on same rule
   PostgreSQL uses (*tablename_columnname_seq* but if the resultant name is determined to be greater than 
-  63 characters, an additional query will be made to database schema to find what PostgreSQL has created 
+  63 bytes, an additional query will be made to database schema to find what PostgreSQL has created 
   instead, since transaction rules are more complex.
   
   This is important to know if you have long table and column names, and do not want
   to run an extra metadata query on every `TableGateway` object construction. If that is the case,
   take note of what PostgreSQL created using
   ```sql
-    SELECT 'column_default'
-    FROM information_schema.columns 
-    WHERE table_schema = 'public'
-      AND table_name = 'artist'
-      AND column_name = 'id'
-      AND column_default LIKE 'nextval%';
+    pg_get_serial_sequence('artist', 'id');
   ```
   
   take note of what `nextval` is reading from, and add it to `SequenceFeature` constructor.

--- a/doc/book/table-gateway.md
+++ b/doc/book/table-gateway.md
@@ -220,10 +220,10 @@ There are a number of features built-in and shipped with zend-db:
   These are usually used for automatically generating Primary Key IDs (similar to MySQL's
   `AUTO_INCREMENT` but without performance penalties), or ensuring uniqueness of entity IDs
   across multiple tables following some business rule (for example, unique invoice numbers across
-  multiple order systems).  Sequence objects are 
-  exclusively used for incrementing an integer and are not tied to table values. Therefore, they
-  need to be created manually prior to inserting data into tables requiring PKs and `UNIQUE` columns
-  using DDL 
+  multiple order systems).  Sequence objects are   exclusively used for incrementing an integer
+  by specified interval (1 by default) and are not tied to table values. Therefore,
+  they need to be created manually prior to inserting data into tables requiring PKs and `UNIQUE`
+  columns using DDL 
    ```sql
      CREATE SEQUENCE album_id;
     ``` 

--- a/doc/book/table-gateway.md
+++ b/doc/book/table-gateway.md
@@ -296,7 +296,7 @@ There are a number of features built-in and shipped with zend-db:
     pg_get_serial_sequence('artist', 'id');
   ```
   
-  take note of what `nextval` is reading from, and add it to `SequenceFeature` constructor.
+  and add it to `SequenceFeature` constructor.
   
   There could be complex business rules needing multiple sequences in a table. `TableGateway` can have
   multiple sequences added in an array:

--- a/src/Sql/Ddl/Column/Serial.php
+++ b/src/Sql/Ddl/Column/Serial.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Ddl\Column;
+
+/**
+ * Column for PostgreSQL to automatically increment column.
+ *
+ * Similar to MySQL's autoincrement, but without performance issues.
+ * Used in conjunction with SequenceFeature.
+ */
+class Serial extends Column
+{
+    protected $type = 'SERIAL';
+}

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -26,7 +26,6 @@ use Zend\Db\TableGateway\Feature\EventFeatureEventsInterface;
  *
  * @property AdapterInterface $adapter
  * @property int $lastInsertValue
- * @property string $table
  */
 abstract class AbstractTableGateway implements TableGatewayInterface
 {
@@ -83,7 +82,6 @@ abstract class AbstractTableGateway implements TableGatewayInterface
      * Initialize
      *
      * @throws Exception\RuntimeException
-     * @return null
      */
     public function initialize()
     {
@@ -122,7 +120,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     /**
      * Get table name
      *
-     * @return string
+     * @return string|array|TableIdentifier
      */
     public function getTable()
     {

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -77,11 +77,13 @@ class FeatureSet
 
     public function apply($method, $args)
     {
-        foreach ($this->features as $feature) {
-            if (method_exists($feature, $method)) {
-                $return = call_user_func_array([$feature, $method], $args);
-                if ($return === self::APPLY_HALT) {
-                    break;
+        foreach ($this->features as $featureClass => $featureSet) {
+            foreach($featureSet as $feature) {
+                if (method_exists($feature, $method)) {
+                    $return = call_user_func_array([$feature, $method], $args);
+                    if ($return === self::APPLY_HALT) {
+                        break;
+                    }
                 }
             }
         }

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -39,7 +39,7 @@ class FeatureSet
     {
         $this->tableGateway = $tableGateway;
         foreach ($this->features as $featureClass => $featureSet) {
-            foreach($featureSet as $feature) {
+            foreach ($featureSet as $feature) {
                 $feature->setTableGateway($this->tableGateway);
             }
         }
@@ -48,10 +48,12 @@ class FeatureSet
 
     public function getFeatureByClassName($featureClassName)
     {
-        if(!array_key_exists($featureClassName, $this->features)) return false;
+        if (!array_key_exists($featureClassName, $this->features)) {
+            return false;
+        }
 
         $featuresByType = $this->features[$featureClassName];
-        if(count($featuresByType) == 1) {
+        if (count($featuresByType) == 1) {
             return $featuresByType[0];
         } else {
             return $featuresByType;
@@ -78,7 +80,7 @@ class FeatureSet
     public function apply($method, $args)
     {
         foreach ($this->features as $featureClass => $featureSet) {
-            foreach($featureSet as $feature) {
+            foreach ($featureSet as $feature) {
                 if (method_exists($feature, $method)) {
                     $return = call_user_func_array([$feature, $method], $args);
                     if ($return === self::APPLY_HALT) {
@@ -159,7 +161,7 @@ class FeatureSet
                 // iterator management instead of foreach to avoid extra conditions and indentations
                 reset($featuresSet);
                 $featureReturn = null;
-                while($featureReturn === null) {
+                while ($featureReturn === null) {
                     $current = current($featuresSet);
                     $featureReturn = $current->$method($arguments);
                     next($featuresSet);

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -38,8 +38,10 @@ class FeatureSet
     public function setTableGateway(AbstractTableGateway $tableGateway)
     {
         $this->tableGateway = $tableGateway;
-        foreach ($this->features as $feature) {
-            $feature->setTableGateway($this->tableGateway);
+        foreach ($this->features as $featureClass => $featureSet) {
+            foreach($featureSet as $feature) {
+                $feature->setTableGateway($this->tableGateway);
+            }
         }
         return $this;
     }

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -107,8 +107,10 @@ class SequenceFeature extends AbstractFeature
      * Return the most recent value from the specified sequence in the database.
      * @return int
      */
-    public function lastSequenceId()
+    public function lastSequenceId($sequenceName = null)
     {
+        if($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) return null;
+
         $platform = $this->tableGateway->adapter->getPlatform();
         $platformName = $platform->getName();
 

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
@@ -32,9 +34,8 @@ class SequenceFeature extends AbstractFeature
      */
     protected $sequenceValue;
 
-
     /**
-     * @param string $sequencedColumn
+     * @param string            $sequencedColumn
      * @param string|array|null $sequenceName
      */
     public function __construct($sequencedColumn, $sequenceName = null)
@@ -46,7 +47,8 @@ class SequenceFeature extends AbstractFeature
     /**
      * @return string
      */
-    public function getSequenceName() {
+    public function getSequenceName()
+    {
         if ($this->sequenceName !== null) {
             return $this->sequenceName;
         }
@@ -60,31 +62,32 @@ class SequenceFeature extends AbstractFeature
         // (case for large resultant identifier names)
         $tableName = '';
 
-        $sequenceSuffix = '_' . $this->sequencedColumn . '_seq';
+        $sequenceSuffix = '_'.$this->sequencedColumn.'_seq';
         // To find whether exceed identifier length, need to keep track of combination of
         // table name ane suffix but not including schema name.
         // Since schema has to be appended in the end,
         $sequenceObjectName = '';
 
-        if(is_string($tableIdentifier)) {
+        if (is_string($tableIdentifier)) {
             $tableName = $tableIdentifier;
 
-            $sequenceObjectName = $this->sequenceName = $tableIdentifier . $sequenceSuffix;
-        } elseif(is_array($tableIdentifier)) {
+            $sequenceObjectName = $this->sequenceName = $tableIdentifier.$sequenceSuffix;
+        } elseif (is_array($tableIdentifier)) {
             // assuming key 0 is schema name
             $tableName = $tableIdentifier[1];
 
             $this->sequenceName = $tableIdentifier;
             $this->sequenceName[1] = $tableName.$sequenceSuffix;
             $sequenceObjectName = $this->sequenceName[1];
-        } elseif($tableIdentifier instanceof TableIdentifier) {
+        } elseif ($tableIdentifier instanceof TableIdentifier) {
             $tableName = $tableIdentifier->getTable();
             $sequenceObjectName = $tableName.$sequenceSuffix;
             $this->sequenceName = $tableIdentifier->hasSchema() ? [$tableIdentifier->getSchema(), $sequenceObjectName] : $sequenceObjectName;
         }
 
-        if(strlen($sequenceObjectName) < 64 ) {
+        if (strlen($sequenceObjectName) < 64) {
             $this->sequenceName = $platform->quoteIdentifierChain($this->sequenceName);
+
             return  $this->sequenceName;
         }
 
@@ -101,6 +104,7 @@ class SequenceFeature extends AbstractFeature
 
     /**
      * @param Insert $insert
+     *
      * @return Insert
      */
     public function preInsert(Insert $insert)
@@ -110,6 +114,7 @@ class SequenceFeature extends AbstractFeature
         $key = array_search($this->sequencedColumn, $columns);
         if ($key !== false) {
             $this->sequenceValue = $values[$key];
+
             return $insert;
         }
 
@@ -119,12 +124,13 @@ class SequenceFeature extends AbstractFeature
         }
 
         $insert->values([$this->sequencedColumn => $this->sequenceValue],  Insert::VALUES_MERGE);
+
         return $insert;
     }
 
     /**
      * @param StatementInterface $statement
-     * @param ResultInterface $result
+     * @param ResultInterface    $result
      */
     public function postInsert(StatementInterface $statement, ResultInterface $result)
     {
@@ -135,8 +141,10 @@ class SequenceFeature extends AbstractFeature
 
     /**
      * Generate a new value from the specified sequence in the database, and return it.
+     *
      * @param $columnName string Column name which this sequence instance is expected to manage.
      * If expectation does not match, ignore the call.
+     *
      * @return int
      */
     public function nextSequenceId($columnName = null)
@@ -152,7 +160,7 @@ class SequenceFeature extends AbstractFeature
 
         switch ($platformName) {
             case 'Oracle':
-                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.NEXTVAL as "nextval" FROM dual';
+                $sql = 'SELECT '.$platform->quoteIdentifier($this->sequenceName).'.NEXTVAL as "nextval" FROM dual';
                 $param = [];
                 break;
             case 'PostgreSQL':
@@ -168,13 +176,16 @@ class SequenceFeature extends AbstractFeature
         $result = $statement->execute($param);
         $sequence = $result->current();
         unset($statement, $result);
+
         return $sequence['nextval'];
     }
 
     /**
      * Return the most recent value from the specified sequence in the database.
+     *
      * @param $columnName string Column name which this sequence instance is expected to manage.
      * If expectation does not match, ignore the call.
+     *
      * @return int
      */
     public function lastSequenceId($columnName = null)
@@ -190,7 +201,7 @@ class SequenceFeature extends AbstractFeature
 
         switch ($platformName) {
             case 'Oracle':
-                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.CURRVAL as "currval" FROM dual';
+                $sql = 'SELECT '.$platform->quoteIdentifier($this->sequenceName).'.CURRVAL as "currval" FROM dual';
                 $param = [];
                 break;
             case 'PostgreSQL':
@@ -207,6 +218,7 @@ class SequenceFeature extends AbstractFeature
         $result = $statement->execute($param);
         $sequence = $result->current();
         unset($statement, $result);
+
         return $sequence['currval'];
     }
 }

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -109,8 +109,8 @@ class SequenceFeature extends AbstractFeature
      */
     public function lastSequenceId($sequenceName = null)
     {
-        if($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) {
-            return null;
+        if ($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) {
+            return;
         }
 
         $platform = $this->tableGateway->adapter->getPlatform();

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -109,7 +109,9 @@ class SequenceFeature extends AbstractFeature
      */
     public function lastSequenceId($sequenceName = null)
     {
-        if($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) return null;
+        if($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) {
+            return null;
+        }
 
         $platform = $this->tableGateway->adapter->getPlatform();
         $platformName = $platform->getName();

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -49,14 +49,19 @@ class SequenceFeature extends AbstractFeature
      */
     public function getSequenceName()
     {
-        if ($this->sequenceName !== null) {
-            return $this->sequenceName;
-        }
-
         //@TODO move to PostgreSQL specific class (possibly decorator)
         /** @var Adapter $adapter */
         $adapter = $this->tableGateway->getAdapter();
         $platform = $adapter->getPlatform();
+
+        if ($this->sequenceName !== null) {
+            if (is_array($this->sequenceName)) {
+                $this->sequenceName = $platform->quoteIdentifierChain($this->sequenceName);
+            }
+
+            return $this->sequenceName;
+        }
+
         $tableIdentifier = $this->tableGateway->getTable();
         // need to preserve table name in case have to query postgres metadata
         // (case for large resultant identifier names)

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -20,7 +20,7 @@ class SequenceFeature extends AbstractFeature
     /**
      * @var string
      */
-    protected $primaryKeyField;
+    protected $sequencedColumn;
 
     /**
      * @var string
@@ -34,12 +34,12 @@ class SequenceFeature extends AbstractFeature
 
 
     /**
-     * @param string $primaryKeyField
+     * @param string $sequencedColumn
      * @param string|array|null $sequenceName
      */
-    public function __construct($primaryKeyField, $sequenceName = null)
+    public function __construct($sequencedColumn, $sequenceName = null)
     {
-        $this->primaryKeyField = $primaryKeyField;
+        $this->sequencedColumn = $sequencedColumn;
         $this->sequenceName    = $sequenceName;
     }
 
@@ -60,7 +60,7 @@ class SequenceFeature extends AbstractFeature
         // (case for large resultant identifier names)
         $tableName = '';
 
-        $sequenceSuffix = '_' . $this->primaryKeyField . '_seq';
+        $sequenceSuffix = '_' . $this->sequencedColumn . '_seq';
         // To find whether exceed identifier length, need to keep track of combination of
         // table name ane suffix but not including schema name.
         // Since schema has to be appended in the end,
@@ -90,7 +90,7 @@ class SequenceFeature extends AbstractFeature
 
         $statement = $adapter->createStatement();
         $statement->prepare('SELECT pg_get_serial_sequence(:table, :column)');
-        $result = $statement->execute(['table' => $tableIdentifier, 'column' => $this->primaryKeyField]);
+        $result = $statement->execute(['table' => $tableIdentifier, 'column' => $this->sequencedColumn]);
         $this->sequenceName = $result->current()['pg_get_serial_sequence'];
 
         // there could be a benefit porting this algorithm here instead of extra query call
@@ -107,7 +107,7 @@ class SequenceFeature extends AbstractFeature
     {
         $columns = $insert->getRawState('columns');
         $values = $insert->getRawState('values');
-        $key = array_search($this->primaryKeyField, $columns);
+        $key = array_search($this->sequencedColumn, $columns);
         if ($key !== false) {
             $this->sequenceValue = $values[$key];
             return $insert;
@@ -118,7 +118,7 @@ class SequenceFeature extends AbstractFeature
             return $insert;
         }
 
-        $insert->values([$this->primaryKeyField => $this->sequenceValue],  Insert::VALUES_MERGE);
+        $insert->values([$this->sequencedColumn => $this->sequenceValue],  Insert::VALUES_MERGE);
         return $insert;
     }
 
@@ -141,7 +141,7 @@ class SequenceFeature extends AbstractFeature
      */
     public function nextSequenceId($columnName = null)
     {
-        if ($columnName !== null && strcmp($columnName, $this->primaryKeyField) !== 0) {
+        if ($columnName !== null && strcmp($columnName, $this->sequencedColumn) !== 0) {
             return;
         }
 
@@ -179,7 +179,7 @@ class SequenceFeature extends AbstractFeature
      */
     public function lastSequenceId($columnName = null)
     {
-        if ($columnName !== null && strcmp($columnName, $this->primaryKeyField) !== 0) {
+        if ($columnName !== null && strcmp($columnName, $this->sequencedColumn) !== 0) {
             return;
         }
 

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -106,10 +106,16 @@ class SequenceFeature extends AbstractFeature
 
     /**
      * Generate a new value from the specified sequence in the database, and return it.
+     * @param $columnName string Column name which this sequence instance is expected to manage.
+     * If expectation does not match, ignore the call.
      * @return int
      */
-    public function nextSequenceId()
+    public function nextSequenceId($columnName = null)
     {
+        if ($columnName !== null && strcmp($columnName, $this->primaryKeyField) !== 0) {
+            return;
+        }
+
         $platform = $this->tableGateway->adapter->getPlatform();
         $platformName = $platform->getName();
 
@@ -134,11 +140,13 @@ class SequenceFeature extends AbstractFeature
 
     /**
      * Return the most recent value from the specified sequence in the database.
+     * @param $columnName string Column name which this sequence instance is expected to manage.
+     * If expectation does not match, ignore the call.
      * @return int
      */
-    public function lastSequenceId($sequenceName = null)
+    public function lastSequenceId($columnName = null)
     {
-        if ($sequenceName !== null && strcmp($sequenceName, $this->sequenceName) !== 0) {
+        if ($columnName !== null && strcmp($columnName, $this->primaryKeyField) !== 0) {
             return;
         }
 

--- a/test/Sql/Ddl/Column/SerialTest.php
+++ b/test/Sql/Ddl/Column/SerialTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Ddl\Column;
+
+use Zend\Db\Sql\Ddl\Column\Serial;
+use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
+
+class SerialTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetExpressionData()
+    {
+        $column = new Serial('id');
+        $this->assertEquals(
+            [['%s %s NOT NULL', ['id', 'SERIAL'], [$column::TYPE_IDENTIFIER, $column::TYPE_LITERAL]]],
+            $column->getExpressionData()
+        );
+
+        $column = new Serial('id');
+        $column->addConstraint(new PrimaryKey());
+        $this->assertEquals(
+            [
+                ['%s %s NOT NULL', ['id', 'SERIAL'], [$column::TYPE_IDENTIFIER, $column::TYPE_LITERAL]],
+                ' ',
+                ['PRIMARY KEY', [], []],
+            ],
+            $column->getExpressionData()
+        );
+    }
+}

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
@@ -50,7 +52,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         //feature doesn't have tableGateway, but FeatureSet has
         $feature = new MasterSlaveFeature($mockSlaveAdapter);
 
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $featureSet->setTableGateway($tableGatewayMock);
 
         $this->assertInstanceOf('Zend\Db\TableGateway\Feature\FeatureSet', $featureSet->addFeature($feature));
@@ -77,7 +79,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         $feature = new MetadataFeature($metadataMock);
         $feature->setTableGateway($tableGatewayMock);
 
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $this->assertInstanceOf('Zend\Db\TableGateway\Feature\FeatureSet', $featureSet->addFeature($feature));
     }
 
@@ -94,7 +96,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             get_class($featureMock),
             $featureSet->getFeatureByClassName(get_class($featureMock)),
-            "When only one feature of its type is added to FeatureSet, getFeatureByClassName() should return that single instance"
+            'When only one feature of its type is added to FeatureSet, getFeatureByClassName() should return that single instance'
         );
     }
 
@@ -112,7 +114,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
 
         $features = $featureSet->getFeatureByClassName(get_class($featureMock1));
 
-        $this->assertTrue(is_array($features), "When multiple features of same type are added, they all should be return in array");
+        $this->assertTrue(is_array($features), 'When multiple features of same type are added, they all should be return in array');
 
         $this->assertInstanceOf(get_class($featureMock1), $features[0]);
         $this->assertInstanceOf(get_class($featureMock2), $features[1]);
@@ -129,7 +131,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $featureSet->getFeatureByClassName(get_class($featureMock)),
-            "Requesting unregistered feature should return false"
+            'Requesting unregistered feature should return false'
         );
     }
 
@@ -139,12 +141,12 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     public function testCanCallMagicCallReturnsTrueForAddedMethodOfAddedFeature()
     {
         $feature = new SequenceFeature('id', 'table_sequence');
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $featureSet->addFeature($feature);
 
         $this->assertTrue(
             $featureSet->canCallMagicCall('lastSequenceId'),
-            "Should have been able to call lastSequenceId from the Sequence Feature"
+            'Should have been able to call lastSequenceId from the Sequence Feature'
         );
     }
 
@@ -154,12 +156,12 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     public function testCanCallMagicCallReturnsFalseForAddedMethodOfAddedFeature()
     {
         $feature = new SequenceFeature('id', 'table_sequence');
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $featureSet->addFeature($feature);
 
         $this->assertFalse(
             $featureSet->canCallMagicCall('postInitialize'),
-            "Should have been able to call postInitialize from the MetaData Feature"
+            'Should have been able to call postInitialize from the MetaData Feature'
         );
     }
 
@@ -168,7 +170,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanCallMagicCallReturnsFalseWhenNoFeaturesHaveBeenAdded()
     {
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $this->assertFalse(
             $featureSet->canCallMagicCall('lastSequenceId')
         );
@@ -179,7 +181,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
      */
     public function testCallMagicCallSucceedsForValidMethodOfAddedFeature()
     {
-        $featureSet = new FeatureSet;
+        $featureSet = new FeatureSet();
         $featureSet->addFeature($this->getMockSequence('table_name', 'sequence_name', 1));
         $this->assertEquals(1, $featureSet->callMagicCall('lastSequenceId', null));
     }

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -12,12 +12,13 @@
 namespace ZendTest\Db\TableGateway\Feature;
 
 use ReflectionClass;
+use Zend\Db\Metadata\Object\ConstraintObject;
 use Zend\Db\TableGateway\Feature\AbstractFeature;
 use Zend\Db\TableGateway\Feature\FeatureSet;
 use Zend\Db\TableGateway\Feature\MasterSlaveFeature;
-use Zend\Db\TableGateway\Feature\SequenceFeature;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
-use Zend\Db\Metadata\Object\ConstraintObject;
+use Zend\Db\TableGateway\Feature\SequenceFeature;
+use ZendTest\Db\TestAsset\TrustingPostgresqlPlatform;
 
 class FeatureSetTest extends \PHPUnit_Framework_TestCase
 {
@@ -221,17 +222,16 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
             ->method('execute')
             ->will($this->returnValue($resultMock));
 
-        $adapterMock = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adapterMock = $this->getMock('Zend\Db\Adapter\Adapter', ['getPlatform', 'createStatement'], [], '', false);
+        $adapterMock->expects($this->any())
+            ->method('getPlatform')
+            ->will($this->returnValue(new TrustingPostgresqlPlatform()));
         $adapterMock->expects($this->any())
             ->method('getPlatform')->will($this->returnValue($platformMock));
         $adapterMock->expects($this->any())
             ->method('createStatement')->will($this->returnValue($statementMock));
 
-        $tableGatewayMock = $this->getMockBuilder('Zend\Db\TableGateway\AbstractTableGateway')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\TableGateway', ['table', $adapterMock], '', true);
 
         $reflectionClass = new ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
         $reflectionProperty = $reflectionClass->getProperty('adapter');

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -180,7 +180,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     public function testCallMagicCallSucceedsForValidMethodOfAddedFeature()
     {
         $featureSet = new FeatureSet;
-        $featureSet->addFeature($this->getMockSequence('table_sequence', 1));
+        $featureSet->addFeature($this->getMockSequence('table_name', 'sequence_name', 1));
         $this->assertEquals(1, $featureSet->callMagicCall('lastSequenceId', null));
     }
 
@@ -191,17 +191,17 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     {
         $featureSet = new FeatureSet();
 
-        $featureSet->addFeature($this->getMockSequence('seq_1', 1));
-        $featureSet->addFeature($this->getMockSequence('seq_2', 2));
-        $featureSet->addFeature($this->getMockSequence('seq_3', 3));
+        $featureSet->addFeature($this->getMockSequence('col_1', 'seq_1', 1));
+        $featureSet->addFeature($this->getMockSequence('col_2', 'seq_2', 2));
+        $featureSet->addFeature($this->getMockSequence('col_3', 'seq_3', 3));
 
-        $result = $featureSet->callMagicCall('lastSequenceId', 'seq_2');
+        $result = $featureSet->callMagicCall('lastSequenceId', 'col_2');
 
         $this->assertEquals(2, $result);
     }
 
     // FeatureSet uses method_exists which does not work on mock objects. Therefore, need a real object.
-    private function getMockSequence($sequenceName, $expectedCurrVal)
+    private function getMockSequence($columnName, $sequenceName, $expectedCurrVal)
     {
         $platformMock = $this->getMock('Zend\Db\Adapter\Platform\Postgresql');
         $platformMock->expects($this->any())
@@ -214,8 +214,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
 
         $statementMock = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
         $statementMock->expects($this->any())
-            ->method('prepare')
-            ->with('SELECT CURRVAL(\'' . $sequenceName . '\')');
+            ->method('prepare');
         $statementMock->expects($this->any())
             ->method('execute')
             ->will($this->returnValue($resultMock));
@@ -237,7 +236,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($tableGatewayMock, $adapterMock);
 
-        $feature = new SequenceFeature('id', $sequenceName);
+        $feature = new SequenceFeature($columnName, $sequenceName);
         $feature->setTableGateway($tableGatewayMock);
 
         return $feature;

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -84,7 +84,8 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\TableGateway\Feature\FeatureSet::getFeatureByClassName
      */
-    public function testGetSingleFeatureByClassName() {
+    public function testGetSingleFeatureByClassName()
+    {
         $featureMock = $this->getMock(AbstractFeature::class);
 
         $featureSet = new FeatureSet();
@@ -100,7 +101,8 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\TableGateway\Feature\FeatureSet::getFeatureByClassName
      */
-    public function testGetAllFeaturesOfSameTypeByClassName() {
+    public function testGetAllFeaturesOfSameTypeByClassName()
+    {
         $featureMock1 = $this->getMock(AbstractFeature::class);
         $featureMock2 = $this->getMock(AbstractFeature::class);
 
@@ -119,7 +121,8 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\TableGateway\Feature\FeatureSet::getFeatureByClassName
      */
-    public function testGetFeatureByClassNameReturnsFalseIfNotAdded() {
+    public function testGetFeatureByClassNameReturnsFalseIfNotAdded()
+    {
         $featureMock = $this->getMock(AbstractFeature::class);
 
         $featureSet = new FeatureSet();
@@ -184,7 +187,8 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\TableGateway\Feature\FeatureSet::callMagicCall
      */
-    public function testCallMagicMethodAllSimilarFeaturesUntilNotNull() {
+    public function testCallMagicMethodAllSimilarFeaturesUntilNotNull()
+    {
         $featureSet = new FeatureSet();
 
         $featureSet->addFeature($this->getMockSequence('seq_1', 1));
@@ -197,7 +201,8 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
     }
 
     // FeatureSet uses method_exists which does not work on mock objects. Therefore, need a real object.
-    private function getMockSequence($sequenceName, $expectedCurrVal) {
+    private function getMockSequence($sequenceName, $expectedCurrVal)
+    {
         $platformMock = $this->getMock('Zend\Db\Adapter\Platform\Postgresql');
         $platformMock->expects($this->any())
             ->method('getName')->will($this->returnValue('PostgreSQL'));

--- a/test/TableGateway/Feature/FeatureSetTest.php
+++ b/test/TableGateway/Feature/FeatureSetTest.php
@@ -195,7 +195,7 @@ class FeatureSetTest extends \PHPUnit_Framework_TestCase
         $featureSet->addFeature($this->getMockSequence('seq_2', 2));
         $featureSet->addFeature($this->getMockSequence('seq_3', 3));
 
-        $result = $featureSet->callMagicCall('lastSequenceId','seq_2');
+        $result = $featureSet->callMagicCall('lastSequenceId', 'seq_2');
 
         $this->assertEquals(2, $result);
     }

--- a/test/TableGateway/Feature/SequenceFeatureTest.php
+++ b/test/TableGateway/Feature/SequenceFeatureTest.php
@@ -70,6 +70,9 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @dataProvider nextSequenceIdProvider
+     */
     public function testNextSequenceIdForSerialColumn($platformName, $statementSql)
     {
         $platform = $this->getMockForAbstractClass('Zend\Db\Adapter\Platform\PlatformInterface', ['getName']);
@@ -99,9 +102,15 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($statement));
         $this->tableGateway = $this->getMockForAbstractClass('Zend\Db\TableGateway\TableGateway', ['table', $adapter], '', true);
 
-        $feature = new SequenceFeature($this->primaryKeyField);
+        $feature = new SequenceFeature($this->primaryKeyField, $this->sequenceName);
         $feature->setTableGateway($this->tableGateway);
         $feature->nextSequenceId();
+    }
+
+    public function testDoNotReactToDifferentColumnName() {
+        $sequence1 = new SequenceFeature('col_1', 'seq_1');
+        $this->assertEquals($sequence1->lastSequenceId('col_2'), null, 'Sequence should not react to foreign column name');
+        $this->assertEquals($sequence1->nextSequenceId('col_2'), null, 'Sequence should not react to foreign column name');
     }
 
     public function nextSequenceIdProvider()

--- a/test/TableGateway/Feature/SequenceFeatureTest.php
+++ b/test/TableGateway/Feature/SequenceFeatureTest.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
@@ -75,7 +77,7 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
     /**
      * Sequences for SERIAL columns start with no name which eventually gets filled.
      * Ensure null value is replaced with actual on first call
-     * so that repeated calls to getSequenceName() do not make extra database calls (for long name case)
+     * so that repeated calls to getSequenceName() do not make extra database calls (for long name case).
      *
      * Also test do not try to generate when name is manually supplied in constructor.
      */
@@ -140,7 +142,6 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
         $feature->nextSequenceId();
     }
 
-
     /**
      * @dataProvider lastSequenceIdProvider
      */
@@ -172,7 +173,8 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
         $feature->lastSequenceId();
     }
 
-    public function testDoNotReactToDifferentColumnName() {
+    public function testDoNotReactToDifferentColumnName()
+    {
         $sequence1 = new SequenceFeature('col_1', 'seq_1');
         $this->assertEquals($sequence1->lastSequenceId('col_2'), null, 'Sequence should not react to foreign column name');
         $this->assertEquals($sequence1->nextSequenceId('col_2'), null, 'Sequence should not react to foreign column name');
@@ -182,7 +184,7 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
     {
         return [
             [new TrustingPostgresqlPlatform(), 'SELECT NEXTVAL( :sequence_name )', ['sequence_name' => $this->sequenceName]],
-            [new TrustingOraclePlatform(),     'SELECT "' . $this->sequenceName . '".NEXTVAL as "nextval" FROM dual', []]
+            [new TrustingOraclePlatform(),     'SELECT "'.$this->sequenceName.'".NEXTVAL as "nextval" FROM dual', []],
         ];
     }
 
@@ -190,7 +192,7 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
     {
         return [
             [new TrustingPostgresqlPlatform(), 'SELECT CURRVAL( :sequence_name )', ['sequence_name' => $this->sequenceName]],
-            [new TrustingOraclePlatform(),     'SELECT "' . $this->sequenceName . '".CURRVAL as "currval" FROM dual', []]
+            [new TrustingOraclePlatform(),     'SELECT "'.$this->sequenceName.'".CURRVAL as "currval" FROM dual', []],
         ];
     }
 
@@ -199,7 +201,7 @@ class SequenceFeatureTest extends PHPUnit_Framework_TestCase
         return [
             ['table', 'table_serial_column_seq'],
             [['schema', 'table'], '"schema"."table_serial_column_seq"'],
-            [new TableIdentifier('table', 'schema'), '"schema"."table_serial_column_seq"']
+            [new TableIdentifier('table', 'schema'), '"schema"."table_serial_column_seq"'],
         ];
     }
 }

--- a/test/TestAsset/TrustingPostgresqlPlatform.php
+++ b/test/TestAsset/TrustingPostgresqlPlatform.php
@@ -1,9 +1,10 @@
 <?php
 
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
@@ -14,7 +15,8 @@ use Zend\Db\Adapter\Platform\Postgresql;
 
 class TrustingPostgresqlPlatform extends Postgresql
 {
-    public function quoteValue($value) {
+    public function quoteValue($value)
+    {
         return $this->quoteTrustedValue($value);
     }
 }

--- a/test/TestAsset/TrustingPostgresqlPlatform.php
+++ b/test/TestAsset/TrustingPostgresqlPlatform.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Postgresql;
+
+class TrustingPostgresqlPlatform extends Postgresql
+{
+    public function quoteValue($value) {
+        return $this->quoteTrustedValue($value);
+    }
+}


### PR DESCRIPTION
#186 [RFC][WIP] Sequence Support

Update 24th December 2016:
---------------------------------
Supersedes, combines PR #162 and #172. Addresses issues brought up by @andrey-mokhov about implicit sequences. To avoid extra query, first constructing name using same naming rule as PostgreSQL and when on rare occasions exceed length, query database. Improve on original solution by using prepared statement in order to cache queries instead of recompiling what is a very common statement with only identifier name variation.
Combines with @xorock solution of specifying schema together with sequence name. Parametrized statement should also deal with error prone manual value escaping.

FeatureSet filter
-------------------------------

First, need to adjust FeatureSet to handle more than one instance of a type to categorize _callMagicCall()_ properly.

This should help with the fact that even though TableGateway accepts unrestricted array of features, if more than one feature of the same type is added, only first one will be processed. Useful for sequences or anyone else who may have run into this.

What I am not fully happy with, could use verification on before I go too far into this:

1. Features of same type now need to have a filter of the target method to ensure they are indeed the target recipient. https://github.com/zendframework/zend-db/compare/master...alextech:sequences?expand=1#diff-85fe938f5a6f87443ad2578472eed9e0R112
This is needed so can have `$tableGateway->lastSequenceId('implicit_by_column_name');` or `$tableGateway->lastSequenceId('explicit_sequence_name');` calls to be delegated to appropriate sequence instance out of the array of them.  Not the cleanest looking solution.

2. Is categorization by class name the best way to go? Is https://github.com/zendframework/zend-db/compare/master...alextech:sequences?expand=1#diff-a46ec23198cadca611ac2ff22cbe055dR156 the best way to loop through them? Maybe to address first point should use combination of feature class name and some unique identifier like name. But then not all features will have an obvious identifier.