### PR TITLE
Pdo/Connection::connect() should not pass platform keys to \PDO constructor

### DIFF
--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -207,6 +207,9 @@ class Connection extends AbstractConnection
                     $value = (array) $value;
                     $options = array_diff_key($options, $value) + $value;
                     break;
+                case 'platform':
+                case 'platform_options':
+                    break;
                 default:
                     $options[$key] = $value;
                     break;


### PR DESCRIPTION
This is to resolve issue #185. With the pdo_ibm driver when passed the platform & platform_options keys it stops processing anything after that. Might be an issue with other drivers but I'm not sure. Since the platform & platform_options key are specifically related to zend-db I don't see any reason we'd ever want them passed to \PDO. Also even if the base \PDO driver needed those keys for some reason they could be put in a driver_options array which is what I am personally already doing anyway.