### PR TITLE
#192 spaces in order function

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -651,7 +651,7 @@ class Select extends AbstractPreparableSql
                     $v = self::ORDER_ASCENDING;
                 }
             }
-            if (strtoupper(trim($v)) == self::ORDER_DESCENDING) {
+            if (strcasecmp(trim($v), self::ORDER_DESCENDING) === 0) {
                 $orders[] = [$platform->quoteIdentifierInFragment($k), self::ORDER_DESCENDING];
             } else {
                 $orders[] = [$platform->quoteIdentifierInFragment($k), self::ORDER_ASCENDING];

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -651,7 +651,7 @@ class Select extends AbstractPreparableSql
                     $v = self::ORDER_ASCENDING;
                 }
             }
-            if (strtoupper($v) == self::ORDER_DESCENDING) {
+            if (strtoupper(trim($v)) == self::ORDER_DESCENDING) {
                 $orders[] = [$platform->quoteIdentifierInFragment($k), self::ORDER_DESCENDING];
             } else {
                 $orders[] = [$platform->quoteIdentifierInFragment($k), self::ORDER_ASCENDING];

--- a/test/Sql/SelectTest.php
+++ b/test/Sql/SelectTest.php
@@ -422,6 +422,10 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @testdox unit test: Test order() correctly splits parameters.
+     * @covers Zend\Db\Sql\Select::order
+     */
     public function testOrderCorrectlySplitsParameter()
     {
         $select = new Select;

--- a/test/Sql/SelectTest.php
+++ b/test/Sql/SelectTest.php
@@ -10,14 +10,14 @@
 namespace ZendTest\Db\Sql;
 
 use ReflectionObject;
-use Zend\Db\Sql\Select;
-use Zend\Db\Sql\Expression;
-use Zend\Db\Sql\Where;
-use Zend\Db\Sql\Having;
-use Zend\Db\Sql\Predicate;
-use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\Sql92;
+use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\Having;
+use Zend\Db\Sql\Predicate;
+use Zend\Db\Sql\Select;
+use Zend\Db\Sql\TableIdentifier;
+use Zend\Db\Sql\Where;
 use ZendTest\Db\TestAsset\TrustingSql92Platform;
 
 class SelectTest extends \PHPUnit_Framework_TestCase
@@ -398,6 +398,13 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select = new Select;
         $select->order(['name ASC', 'age DESC']);
         $this->assertEquals(['name ASC', 'age DESC'], $select->getRawState('order'));
+
+        $select = new Select;
+        $select->order('name  DESC');
+        $this->assertEquals(
+            'SELECT * ORDER BY "name" DESC',
+            $select->getSqlString(new TrustingSql92Platform())
+        );
 
         $select = new Select;
         $select->order(new Expression('RAND()'));

--- a/test/Sql/SelectTest.php
+++ b/test/Sql/SelectTest.php
@@ -400,13 +400,6 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['name ASC', 'age DESC'], $select->getRawState('order'));
 
         $select = new Select;
-        $select->order('name  DESC');
-        $this->assertEquals(
-            'SELECT * ORDER BY "name" DESC',
-            $select->getSqlString(new TrustingSql92Platform())
-        );
-
-        $select = new Select;
         $select->order(new Expression('RAND()'));
         $sr = new ReflectionObject($select);
         $method = $sr->getMethod('processOrder');
@@ -426,6 +419,16 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             [[['"rating" < \'10\'']]],
             $method->invokeArgs($select, [new TrustingSql92Platform()])
+        );
+    }
+
+    public function testOrderCorrectlySplitsParameter()
+    {
+        $select = new Select;
+        $select->order('name  desc');
+        $this->assertEquals(
+            'SELECT * ORDER BY "name" DESC',
+            $select->getSqlString(new TrustingSql92Platform())
         );
     }
 


### PR DESCRIPTION
Fixing #192 processing of ORDER BY correctly splits by multiple spaces, but ignores the fact that extra spaces are still there.