### PR TITLE
Updated docblock on join to show TableIdentifer is allowed

### DIFF
--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -108,7 +108,7 @@ class Join implements Iterator, Countable
     }
 
     /**
-     * @param string|array $name A table name on which to join, or a single
+     * @param string|array|TableIdentifier $name A table name on which to join, or a single
      *     element associative array, of the form alias => table
      * @param string $on A string specification describing the fields to join on.
      * @param string|string[]|int|int[] $columns A single column name, an array

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -254,7 +254,7 @@ class Select extends AbstractPreparableSql
     /**
      * Create join clause
      *
-     * @param  string|array $name
+     * @param  string|array|TableIdentifier $name
      * @param  string $on
      * @param  string|array $columns
      * @param  string $type one of the JOIN_* constants


### PR DESCRIPTION
In addition to accepting strings and arrays, TableIdentifier is allowed and sometimes necessary. This updates the doc block for Select and Join to include it so Intellisense in IDEs will show this could work.