### PR TITLE
MySQL "ADD COLUMN ... AFTER ..." support

### DIFF
--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -33,6 +33,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
         'columnformat'  => 4,
         'format'        => 4,
         'storage'       => 5,
+        'after'         => 6
     ];
 
     /**
@@ -130,6 +131,9 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                         $insert = ' STORAGE ' . strtoupper($coValue);
                         $j = 2;
                         break;
+                    case 'after':
+                        $insert = ' AFTER ' . $adapterPlatform->quoteIdentifier($coValue);
+                        $j = 2;
                 }
 
                 if ($insert) {

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -16,7 +16,7 @@ use Zend\Db\Sql\AbstractExpression;
 class In extends AbstractExpression implements PredicateInterface
 {
     protected $identifier;
-    protected $valueSet = [];
+    protected $valueSet;
 
     protected $specification = '%s IN %s';
 

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -16,7 +16,7 @@ use Zend\Db\Sql\AbstractExpression;
 class In extends AbstractExpression implements PredicateInterface
 {
     protected $identifier;
-    protected $valueSet;
+    protected $valueSet = [];
 
     protected $specification = '%s IN %s';
 

--- a/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
@@ -13,7 +13,6 @@ use Zend\Db\Adapter\Platform\Mysql;
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column\Column;
 use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
-use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\Mysql\Ddl\AlterTableDecorator;
 
 class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase

--- a/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform\Mysql\Ddl;
+
+use Zend\Db\Adapter\Platform\Mysql;
+use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl\Column\Column;
+use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
+use Zend\Db\Sql\Ddl\CreateTable;
+use Zend\Db\Sql\Platform\Mysql\Ddl\AlterTableDecorator;
+
+class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Zend\Db\Sql\Platform\Mysql\Ddl\AlterTableDecorator::setSubject
+     */
+    public function testSetSubject()
+    {
+        $ctd = new AlterTableDecorator();
+        $ct = new AlterTable;
+        $this->assertSame($ctd, $ctd->setSubject($ct));
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Platform\Mysql\Ddl\AlterTableDecorator::getSqlString
+     */
+    public function testGetSqlString()
+    {
+        $ctd = new AlterTableDecorator();
+        $ct = new AlterTable('foo');
+        $ctd->setSubject($ct);
+
+        $col = new Column('bar');
+        $col->setOption('zerofill', true);
+        $col->setOption('unsigned', true);
+        $col->setOption('identity', true);
+        $col->setOption('comment', 'baz');
+        $col->setOption('after', 'bar');
+        $col->addConstraint(new PrimaryKey());
+        $ct->addColumn($col);
+
+        $this->assertEquals(
+            "ALTER TABLE `foo`\n ADD COLUMN `bar` INTEGER UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'baz' AFTER `bar`",
+            @$ctd->getSqlString(new Mysql())
+        );
+    }
+}


### PR DESCRIPTION
ZF1 supports MySQL syntax allowing to add a column AFTER another one in an ALTER TABLE statement. ZF2 does not. This PR is intended to fix that.