### PR TITLE
Added SQL Server to Vagrant + fixed tests

### DIFF
--- a/.ci/mysql_fixtures.sh
+++ b/.ci/mysql_fixtures.sh
@@ -2,4 +2,4 @@
 
 echo "Configure MySQL test database"
 
-mysql -u root -pPassword123 -e 'create database zenddb_test;'
+mysql --user=root --password=Password123 -e 'create database zenddb_test;'

--- a/.ci/mysql_fixtures.sh
+++ b/.ci/mysql_fixtures.sh
@@ -2,4 +2,4 @@
 
 echo "Configure MySQL test database"
 
-mysql -u root -e 'create database zenddb_test;'
+mysql -u root -pPassword123 -e 'create database zenddb_test;'

--- a/.ci/mysql_fixtures_travis.sh
+++ b/.ci/mysql_fixtures_travis.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Configure MySQL test database"
+
+mysql -u root -e 'create database zenddb_test;'

--- a/.ci/sqlsrv_fixtures.sh
+++ b/.ci/sqlsrv_fixtures.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Configure SQL server test database"
+
+sqlcmd -S localhost -U sa -P Password123 -Q "CREATE DATABASE zenddb_test;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 env:
   global:
     - TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME=localhost
+    - TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_PASSWORD=
     - TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME=localhost
     - SITE_URL: https://zendframework.github.io/zend-db
     - GH_USER_NAME: "Matthew Weier O'Phinney"
@@ -81,7 +82,7 @@ install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 before_script:
-  - .ci/mysql_fixtures.sh
+  - .ci/mysql_fixtures_travis.sh
   - .ci/pgsql_fixtures.sh
 
 script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,20 +4,43 @@
 $install_software = <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
 apt-get -yq update
-apt-get -yq --no-install-suggests --no-install-recommends --force-yes install mysql-server postgresql
 
-# Allow external connections to MySQL as root
-sed -i 's/127\.0\.0\.1/0\.0\.0\.0/g' /etc/mysql/my.cnf
-mysql -u root -e 'USE mysql; UPDATE `user` SET `Host`="%" WHERE `User`="root" AND `Host`="localhost"; DELETE FROM `user` WHERE `Host` != "%" AND `User`="root"; FLUSH PRIVILEGES;'
-service mysql restart
-
+# INSTALL PostgreSQL
+apt-get -yq install postgresql
 
 # Allow external connections to PostgreSQL as postgres
-sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/9.3/main/postgresql.conf
-sed -i "s/peer/trust/" /etc/postgresql/9.3/main/pg_hba.conf
-echo 'host all all 0.0.0.0/0 trust' >> /etc/postgresql/9.3/main/pg_hba.conf
+sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/9.5/main/postgresql.conf
+sed -i "s/peer/trust/" /etc/postgresql/9.5/main/pg_hba.conf
+echo 'host all all 0.0.0.0/0 trust' >> /etc/postgresql/9.5/main/pg_hba.conf
 service postgresql restart
+
+# INSTALL MySQL
+debconf-set-selections <<< "mysql-server mysql-server/root_password password Password123"
+debconf-set-selections <<< "mysql-server mysql-server/root_password_again password Password123"
+apt-get -yq install mysql-server
+
+# Allow external connections to MySQL as root (with password Password123)
+sed -i 's/127\.0\.0\.1/0\.0\.0\.0/g' /etc/mysql/mysql.conf.d/mysqld.cnf
+mysql -u root -pPassword123 -e 'USE mysql; UPDATE `user` SET `Host`="%" WHERE `User`="root" AND `Host`="localhost"; DELETE FROM `user` WHERE `Host` != "%" AND `User`="root"; FLUSH PRIVILEGES;'
+service mysql restart
+
+# INSTALL SQL Server
+# More info here: https://www.microsoft.com/en-us/sql-server/developer-get-started/php-ubuntu
+
+curl -s https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+curl -s https://packages.microsoft.com/config/ubuntu/16.04/mssql-server.list > /etc/apt/sources.list.d/mssql-server.list
+apt-get -yq update
+apt-get -yq install mssql-server
+printf "YES\nPassword123\nPassword123\ny\ny" | /opt/mssql/bin/sqlservr-setup
+
+curl -s https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-tools.list
+apt-get -yq update
+ACCEPT_EULA=Y apt-get -yq install msodbcsql mssql-tools unixodbc-dev
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> /home/vagrant/.bash_profile
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> /home/vagrant/.bashrc
+source /home/vagrant/.bashrc
 SCRIPT
+
 
 $setup_vagrant_user_environment = <<SCRIPT
 if ! grep "cd /vagrant" /home/vagrant/.profile > /dev/null; then
@@ -26,16 +49,17 @@ fi
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = 'bento/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-16.04'
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 2
+  end
 
-  # MySQL port
-  config.vm.network 'forwarded_port', guest: 3306, host: 3306, auto_correct: true
-
-  # PostgreSQL port
-  config.vm.network 'forwarded_port', guest: 5432, host: 5432, auto_correct: true
+  config.vm.network "private_network", ip: "192.168.20.20"
 
   config.vm.provision 'shell', inline: $install_software
   config.vm.provision 'shell', privileged: false, inline: '/vagrant/.ci/mysql_fixtures.sh'
   config.vm.provision 'shell', privileged: false, inline: '/vagrant/.ci/pgsql_fixtures.sh'
+  config.vm.provision 'shell', privileged: false, inline: '/vagrant/.ci/sqlsrv_fixtures.sh'
   config.vm.provision 'shell', inline: $setup_vagrant_user_environment
 end

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,27 +39,32 @@
              constants appropriate to the component you are migrating. -->
 
         <!-- Integration Test Variables -->
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME" value="" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL" value="false" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME" value="192.168.20.20" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_USERNAME" value="root" />
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_PASSWORD" value="" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_PASSWORD" value="Password123" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_DATABASE" value="zenddb_test" />
 
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_HOSTNAME" value="" />
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_USERNAME" value="" />
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_PASSWORD" value="" />
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_DATABASE" value="" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV" value="false" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_HOSTNAME" value="192.168.20.20" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_USERNAME" value="sa" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_PASSWORD" value="Password123" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_DATABASE" value="zenddb_test" />
 
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_OCI8" value="false" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_OCI8_HOSTNAME" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_OCI8_USERNAME" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_OCI8_PASSWORD" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_OCI8_DATABASE" value="" />
 
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_IBMDB2" value="false" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_IBMDB2_HOSTNAME" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_IBMDB2_USERNAME" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_IBMDB2_PASSWORD" value="" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_IBMDB2_DATABASE" value="" />
 
-        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME" value="" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL" value="false" />
+        <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME" value="192.168.20.20" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_USERNAME" value="postgres" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_PASSWORD" value="postgres" />
         <env name="TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_DATABASE" value="zenddb_test" />

--- a/test/Adapter/Driver/Sqlsrv/AbstractIntegrationTest.php
+++ b/test/Adapter/Driver/Sqlsrv/AbstractIntegrationTest.php
@@ -23,6 +23,9 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        if (!getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV')) {
+            $this->markTestSkipped('SQLSRV tests are not enabled');
+        }
         foreach ($this->variables as $name => $value) {
             if (!getenv($value)) {
                 $this->markTestSkipped('Missing required variable ' . $value . ' from phpunit.xml for this integration test');

--- a/test/Adapter/Driver/Sqlsrv/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/Sqlsrv/StatementIntegrationTest.php
@@ -16,32 +16,8 @@ use Zend\Db\Adapter\Driver\Sqlsrv\Statement;
  * @group integration
  * @group integration-sqlserver
  */
-class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
+class StatementIntegrationTest extends AbstractIntegrationTest
 {
-    protected $variables = [
-        'hostname' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_HOSTNAME',
-        'username' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_USERNAME',
-        'password' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_PASSWORD',
-    ];
-
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     */
-    protected function setUp()
-    {
-        foreach ($this->variables as $name => $value) {
-            if (!getenv($value)) {
-                $this->markTestSkipped('Missing required variable ' . $value . ' from phpunit.xml for this integration test');
-            }
-            $this->variables[$name] = getenv($value);
-        }
-
-        if (!extension_loaded('sqlsrv')) {
-            $this->fail('The phpunit group integration-sqlsrv was enabled, but the extension is not loaded.');
-        }
-    }
-
     /**
      * @covers Zend\Db\Adapter\Driver\Sqlsrv\Statement::initialize
      */

--- a/test/IntegrationTestListener.php
+++ b/test/IntegrationTestListener.php
@@ -29,7 +29,7 @@ class IntegrationTestListener implements PHPUnit_Framework_TestListener
 
     public function __construct()
     {
-        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME')) {
+        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL')) {
             if (extension_loaded('mysqli')) {
                 $this->adapters['mysqli'] = new \mysqli(
                     getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME'),
@@ -46,7 +46,7 @@ class IntegrationTestListener implements PHPUnit_Framework_TestListener
                 );
             }
         }
-        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME')) {
+        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL')) {
             if (extension_loaded('pgsql')) {
                 $this->adapters['pgsql'] = pg_connect(
                     'host=' . getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_PGSQL_HOSTNAME')
@@ -70,7 +70,7 @@ class IntegrationTestListener implements PHPUnit_Framework_TestListener
                 );
             }
         }
-        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_HOSTNAME')) {
+        if (getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV')) {
             if (extension_loaded('sqlsrv')) {
                 $this->adapters['sqlsrv'] = sqlsrv_connect(
                     getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV_HOSTNAME'),


### PR DESCRIPTION
This PR proposes a new Vagrant box using Ubuntu 16.04 with MySQL, PostgreSQL and [SQL Server for Linux](https://www.microsoft.com/en-us/sql-server/sql-server-vnext-including-Linux). The Vagrant box uses a local IP address `192.168.20.20` to facilitate the unit tests for environments that already have one or more database installed. 

I also refactored also `phpunit.xml.dist` using the new ip address and the new default passwords. All the integration test are disabled by default. You need to enable it changing `false` to `true`. For instance, this is the value to change in `phpunit.xml.dist` to execute the integration test of SQL Server:
```xml
<env name="TESTS_ZEND_DB_ADAPTER_DRIVER_SQLSRV" value="true" />
```