### PR TITLE
Add missing test cases for the Join class

### DIFF
--- a/test/Sql/JoinTest.php
+++ b/test/Sql/JoinTest.php
@@ -9,9 +9,79 @@ namespace ZendTest\Db\Sql;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Db\Sql\Join;
+use Zend\Db\Sql\Select;
 
 class JoinTest extends TestCase
 {
+    public function testInitialPositionIsZero()
+    {
+        $join = new Join();
+
+        $this->assertAttributeEquals(0, 'position', $join);
+    }
+
+    public function testNextIncrementsThePosition()
+    {
+        $join = new Join();
+
+        $join->next();
+
+        $this->assertAttributeEquals(1, 'position', $join);
+    }
+
+    public function testRewindResetsPositionToZero()
+    {
+        $join = new Join();
+
+        $join->next();
+        $join->next();
+        $this->assertAttributeEquals(2, 'position', $join);
+
+        $join->rewind();
+        $this->assertAttributeEquals(0, 'position', $join);
+    }
+
+    public function testKeyReturnsTheCurrentPosition()
+    {
+        $join = new Join();
+
+        $join->next();
+        $join->next();
+        $join->next();
+
+        $this->assertEquals(3, $join->key());
+    }
+
+    public function testCurrentReturnsTheCurrentJoinSpecification()
+    {
+        $name = 'baz';
+        $on   = 'foo.id = baz.id';
+
+        $join = new Join();
+        $join->join($name, $on);
+
+        $expectedSpecification = [
+            'name'    => $name,
+            'on'      => $on,
+            'columns' => [Select::SQL_STAR],
+            'type'    => Join::JOIN_INNER,
+        ];
+
+        $this->assertEquals($expectedSpecification, $join->current());
+    }
+
+    public function testValidReturnsTrueIfTheIteratorIsAtAValidPositionAndFalseIfNot()
+    {
+        $join = new Join();
+        $join->join('baz', 'foo.id = baz.id');
+
+        $this->assertTrue($join->valid());
+
+        $join->next();
+
+        $this->assertFalse($join->valid());
+    }
+
     /**
      * @testdox unit test: Test join() returns Join object (is chainable)
      * @covers Zend\Db\Sql\Join::join
@@ -21,6 +91,16 @@ class JoinTest extends TestCase
         $join = new Join;
         $return = $join->join('baz', 'foo.fooId = baz.fooId', Join::JOIN_LEFT);
         $this->assertSame($join, $return);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage join() expects '' as a single element associative array
+     */
+    public function testJoinWillThrowAnExceptionIfNameIsNoValid()
+    {
+        $join = new Join();
+        $join->join([], false);
     }
 
     /**


### PR DESCRIPTION
Hello,

This PR adds a few missing tests cases for the `Join` class. It brings the coverage up to 100%.

Regards,
Rob