### PR TITLE
Add support for empty values set with IN predicate

### DIFF
--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -33,7 +33,7 @@ class In extends AbstractExpression implements PredicateInterface
         if ($identifier) {
             $this->setIdentifier($identifier);
         }
-        if ($valueSet) {
+        if ($valueSet !== null) {
             $this->setValueSet($valueSet);
         }
     }

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -122,9 +122,10 @@ class In extends AbstractExpression implements PredicateInterface
             foreach ($values as $argument) {
                 list($replacements[], $types[]) = $this->normalizeArgument($argument, self::TYPE_VALUE);
             }
+            $values = count($values) > 0 ? array_fill(0, count($values), '%s') : [];
             $specification = vsprintf(
                 $this->specification,
-                [$identifierSpecFragment, '(' . implode(', ', array_fill(0, count($values), '%s')) . ')']
+                [$identifierSpecFragment, '(' . implode(', ', $values) . ')']
             );
         }
 

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -122,10 +122,10 @@ class In extends AbstractExpression implements PredicateInterface
             foreach ($values as $argument) {
                 list($replacements[], $types[]) = $this->normalizeArgument($argument, self::TYPE_VALUE);
             }
-            $values = count($values) > 0 ? array_fill(0, count($values), '%s') : [];
+            $valuePlaceholders = count($values) > 0 ? array_fill(0, count($values), '%s') : [];
             $specification = vsprintf(
                 $this->specification,
-                [$identifierSpecFragment, '(' . implode(', ', $values) . ')']
+                [$identifierSpecFragment, '(' . implode(', ', $valuePlaceholders) . ')']
             );
         }
 

--- a/test/Sql/Predicate/InTest.php
+++ b/test/Sql/Predicate/InTest.php
@@ -29,6 +29,13 @@ class InTest extends TestCase
         $this->assertEquals([1, 2], $in->getValueSet());
     }
 
+    public function testCanPassIdentifierAndEmptyValueSetToConstructor()
+    {
+        $in = new In('foo.bar', []);
+        $this->assertEquals('foo.bar', $in->getIdentifier());
+        $this->assertEquals([], $in->getValueSet());
+    }
+
     public function testIdentifierIsMutable()
     {
         $in = new In();
@@ -78,6 +85,18 @@ class InTest extends TestCase
             '%s IN %s',
             ['foo', $select],
             [$in::TYPE_IDENTIFIER, $in::TYPE_VALUE]
+        ]];
+        $this->assertEquals($expected, $in->getExpressionData());
+    }
+
+    public function testGetExpressionDataWithEmptyValues()
+    {
+        $select = new Select;
+        $in = new In('foo', []);
+        $expected = [[
+            '%s IN ()',
+            ['foo'],
+            [$in::TYPE_IDENTIFIER]
         ]];
         $this->assertEquals($expected, $in->getExpressionData());
     }


### PR DESCRIPTION
(Original PR #196)

It should be possible to construct a IN predicate with empty values set.
```php
$select->where('mycolumn IN ?', []);
```
Of course this code will most likely never be written as is but the content of the set can instead be the result of a calculation.

It's not possible with the current code because of the `if ($valueSet)` in the constructor and the missing default value in the field definition above, which leads to the following error on line 122 when predicate is built:
```
Invalid argument supplied for foreach()
```
Empty sets are supported by some DBMS (SQLite for example) and in that case are the equivalent of `WHERE FALSE` (since no result can be part of an empty set...).