### PR TITLE
Fixes the special characters in bindParam for PDO

### DIFF
--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -298,7 +298,13 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && !is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
-            return ':' . $name;
+            return ':' . preg_replace_callback(
+                '/([^a-zA-Z0-9_])/',
+                function ($matches) {
+                    return ord($matches[0]);
+                },
+                $name
+            );
         }
 
         return '?';

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -298,13 +298,8 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && !is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
-            return ':' . preg_replace_callback(
-                '/([^a-zA-Z0-9_])/',
-                function ($matches) {
-                    return '_' . ord($matches[0]) . '_';
-                },
-                $name
-            );
+            // using MD5 because of the PDO restriction [A-Za-z0-9_] for bindParam name
+            return ':' . md5($name);
         }
 
         return '?';

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -301,7 +301,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
             return ':' . preg_replace_callback(
                 '/([^a-zA-Z0-9_])/',
                 function ($matches) {
-                    return ord($matches[0]);
+                    return '_' . ord($matches[0]) . '_';
                 },
                 $name
             );

--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -289,7 +289,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             }
 
             // parameter is named or positional, value is reference
-            $parameter = is_int($name) ? ($name + 1) : $name;
+            $parameter = is_int($name) ? ($name + 1) : $this->driver->formatParameterName($name);
             $this->resource->bindParam($parameter, $value, $type);
         }
     }

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -42,16 +42,16 @@ class PdoTest extends \PHPUnit_Framework_TestCase
     public function getParamsAndType()
     {
         return [
-            [ 'foo', null, ':foo'],
-            [ 'foo-', null, ':foo_45_'],
-            [ 'foo$', null, ':foo_36_'],
+            [ 'foo', null, ':' . md5('foo')],
+            [ 'foo-', null, ':' . md5('foo-')],
+            [ 'foo$', null, ':' . md5('foo$')],
             [ 1, null, '?' ],
             [ '1', null, '?'],
-            [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':foo'],
-            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':foo_45_'],
-            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':foo_36_'],
-            [ 1, Pdo::PARAMETERIZATION_NAMED, ':1'],
-            [ '1', Pdo::PARAMETERIZATION_NAMED, ':1'],
+            [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo')],
+            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo-')],
+            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo$')],
+            [ 1, Pdo::PARAMETERIZATION_NAMED, ':' . md5('1')],
+            [ '1', Pdo::PARAMETERIZATION_NAMED, ':' . md5('1')],
         ];
     }
 

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -38,4 +38,29 @@ class PdoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SqlServer', $this->pdo->getDatabasePlatformName());
         $this->assertEquals('SQLServer', $this->pdo->getDatabasePlatformName(DriverInterface::NAME_FORMAT_NATURAL));
     }
+
+    public function getParamsAndType()
+    {
+        return [
+            [ 'foo', null, ':foo'],
+            [ 'foo-', null, ':foo45'],
+            [ 'foo$', null, ':foo36'],
+            [ 1, null, '?' ],
+            [ '1', null, '?'],
+            [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':foo'],
+            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':foo45'],
+            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':foo36'],
+            [ 1, Pdo::PARAMETERIZATION_NAMED, ':1'],
+            [ '1', Pdo::PARAMETERIZATION_NAMED, ':1'],
+        ];
+    }
+
+    /**
+     * @dataProvider getParamsAndType
+     */
+    public function testFormatParameterName($name, $type, $expected)
+    {
+        $result = $this->pdo->formatParameterName($name, $type);
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -43,13 +43,13 @@ class PdoTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [ 'foo', null, ':foo'],
-            [ 'foo-', null, ':foo45'],
-            [ 'foo$', null, ':foo36'],
+            [ 'foo-', null, ':foo_45_'],
+            [ 'foo$', null, ':foo_36_'],
             [ 1, null, '?' ],
             [ '1', null, '?'],
             [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':foo'],
-            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':foo45'],
-            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':foo36'],
+            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':foo_45_'],
+            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':foo_36_'],
             [ 1, Pdo::PARAMETERIZATION_NAMED, ':1'],
             [ '1', Pdo::PARAMETERIZATION_NAMED, ':1'],
         ];

--- a/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
@@ -47,7 +47,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
     public function testStatementExecuteWillConvertPhpBoolToPdoBoolWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo('foo'),
+            $this->equalTo(':foo'),
             $this->equalTo(false),
             $this->equalTo(\PDO::PARAM_BOOL)
         );
@@ -57,7 +57,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
     public function testStatementExecuteWillUsePdoStrByDefaultWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo('foo'),
+            $this->equalTo(':foo'),
             $this->equalTo('bar'),
             $this->equalTo(\PDO::PARAM_STR)
         );

--- a/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
@@ -47,7 +47,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
     public function testStatementExecuteWillConvertPhpBoolToPdoBoolWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo(':foo'),
+            $this->equalTo(':' . md5('foo')),
             $this->equalTo(false),
             $this->equalTo(\PDO::PARAM_BOOL)
         );
@@ -57,7 +57,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
     public function testStatementExecuteWillUsePdoStrByDefaultWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo(':foo'),
+            $this->equalTo(':' . md5('foo')),
             $this->equalTo('bar'),
             $this->equalTo(\PDO::PARAM_STR)
         );

--- a/test/Adapter/Driver/Pdo/StatementTest.php
+++ b/test/Adapter/Driver/Pdo/StatementTest.php
@@ -129,7 +129,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @see https://github.com/zendframework/zend-db/pull/178
+     * @see https://github.com/zendframework/zend-db/pull/224
      */
     public function testExecuteWithSpecialCharInBindParam()
     {
@@ -137,7 +137,13 @@ class StatementTest extends \PHPUnit_Framework_TestCase
         $this->statement->setDriver(new Pdo(new Connection($testSqlite)));
         $this->statement->initialize($testSqlite);
 
-        $this->statement->prepare('INSERT INTO test (text_, text$) VALUES (:text_, :text_36_)');
+        $this->statement->prepare(
+            'INSERT INTO test (text_, text$) VALUES (:' .
+            md5('text_') .
+            ', :' .
+            md5('text$') .
+            ')'
+        );
         $result = $this->statement->execute([ 'text_' => 'foo', 'text$' => 'bar']);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->valid());

--- a/test/Adapter/Driver/Pdo/StatementTest.php
+++ b/test/Adapter/Driver/Pdo/StatementTest.php
@@ -137,13 +137,11 @@ class StatementTest extends \PHPUnit_Framework_TestCase
         $this->statement->setDriver(new Pdo(new Connection($testSqlite)));
         $this->statement->initialize($testSqlite);
 
-        $this->statement->prepare(
-            'INSERT INTO test (text_, text$) VALUES (:' .
-            md5('text_') .
-            ', :' .
-            md5('text$') .
-            ')'
-        );
+        $this->statement->prepare(sprintf(
+            'INSERT INTO test (text_, text$) VALUES (:%s, :%s)',
+            md5('text_'),
+            md5('text$')
+        ));
         $result = $this->statement->execute([ 'text_' => 'foo', 'text$' => 'bar']);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->valid());

--- a/test/Adapter/Driver/Pdo/StatementTest.php
+++ b/test/Adapter/Driver/Pdo/StatementTest.php
@@ -137,7 +137,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
         $this->statement->setDriver(new Pdo(new Connection($testSqlite)));
         $this->statement->initialize($testSqlite);
 
-        $this->statement->prepare('INSERT INTO test (text_, text$) VALUES (:text_, :text36)');
+        $this->statement->prepare('INSERT INTO test (text_, text$) VALUES (:text_, :text_36_)');
         $result = $this->statement->execute([ 'text_' => 'foo', 'text$' => 'bar']);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->valid());

--- a/test/Adapter/Driver/Pdo/TestAsset/SqliteMemoryPdo.php
+++ b/test/Adapter/Driver/Pdo/TestAsset/SqliteMemoryPdo.php
@@ -13,8 +13,19 @@ class SqliteMemoryPdo extends \Pdo
 {
     protected $mockStatement;
 
-    public function __construct()
+    public function __construct($sql = null)
     {
         parent::__construct('sqlite::memory:');
+
+        // execute the sql statement if not empty
+        if (!empty($sql)) {
+            if (false === $this->exec($sql)) {
+                throw new \Exception(sprintf(
+                    "Error: %s, %s",
+                    $this->errorCode(),
+                    implode(",", $this->errorInfo())
+                ));
+            }
+        }
     }
 }

--- a/test/Adapter/Driver/Pdo/TestAsset/SqliteMemoryPdo.php
+++ b/test/Adapter/Driver/Pdo/TestAsset/SqliteMemoryPdo.php
@@ -17,15 +17,15 @@ class SqliteMemoryPdo extends \Pdo
     {
         parent::__construct('sqlite::memory:');
 
-        // execute the sql statement if not empty
-        if (!empty($sql)) {
-            if (false === $this->exec($sql)) {
-                throw new \Exception(sprintf(
-                    "Error: %s, %s",
-                    $this->errorCode(),
-                    implode(",", $this->errorInfo())
-                ));
-            }
+        if (empty($sql)) {
+            return;
+        }
+        if (false === $this->exec($sql)) {
+            throw new \Exception(sprintf(
+                "Error: %s, %s",
+                $this->errorCode(),
+                implode(",", $this->errorInfo())
+            ));
         }
     }
 }


### PR DESCRIPTION
This PR solve #35 and replaces #178. The $name in bindParam are replaced with the following, due to the PDO restriction [0-9a-zA-Z_]:
```php
return ':' . md5($name);
```
For instance, a filed name `test$` will be translated in `:79f5d7a7e10367f279c2500dcd03b3de` as bind param name. I used the `md5()` approach after some benchmark tests, see comments and commits below. I also provided unit test and integrational test.