### PR TITLE
Sql Server DDL

### DIFF
--- a/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
@@ -5,7 +5,7 @@
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  *
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
@@ -15,6 +15,7 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl\Column\Column;
 use Zend\Db\Sql\Ddl\Column\Varbinary;
 use Zend\Db\Sql\Exception\InvalidArgumentException;
 use Zend\Db\Sql\ExpressionInterface;
@@ -30,37 +31,36 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     protected $alterSpecifications = [
         self::ADD_COLUMNS  => [
             "%1\$s" => [
-                [2 => "ALTER TABLE %1\$s\n ADD %2\$s;", 'combinedby' => "\n"]
-            ]
+                [2 => "ALTER TABLE %1\$s\n ADD %2\$s;", 'combinedby' => "\n"],
+            ],
         ],
         self::CHANGE_COLUMNS  => [
             "%1\$s" => [
-                [2 => "CHANGE COLUMN %1\$s %2\$s,\n", 'combinedby' => ""],
-            ]
+                [2 => "CHANGE COLUMN %1\$s %2\$s,\n", 'combinedby' => ''],
+            ],
         ],
         self::DROP_COLUMNS  => [
             "%1\$s" => [
-                [1 => "DROP COLUMN %1\$s,\n", 'combinedby' => ""],
-            ]
+                [1 => "DROP COLUMN %1\$s,\n", 'combinedby' => ''],
+            ],
         ],
         self::ADD_CONSTRAINTS  => [
             "%1\$s" => [
                 [2 => "ALTER TABLE %1\$s\n ADD %2\$s;", 'combinedby' => "\n"],
-            ]
+            ],
         ],
         self::DROP_CONSTRAINTS  => [
             "%1\$s" => [
-                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""],
-            ]
+                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ''],
+            ],
         ],
     ];
 
     private $alterTableExpression;
 
-
     /**
      * @var int[]
-     * https://msdn.microsoft.com/en-us/library/ms187742.aspx#Syntax
+     *            https://msdn.microsoft.com/en-us/library/ms187742.aspx#Syntax
      */
     protected $columnOptionSortOrder = [
         'filestream'    => 0,
@@ -89,13 +89,13 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
         return $this;
     }
 
-
     // SqlServer cannot have multiple operations in ALTER TABLE
     // generate on first time, and reuse for all operations
 
 
     /**
      * @param string $sql
+     *
      * @return array
      */
     protected function getSqlInsertOffsets($sql)
@@ -104,7 +104,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
         $insertStart = [];
 
         foreach (['NOT NULL', 'NULL', 'DEFAULT', 'UNIQUE', 'PRIMARY', 'REFERENCES'] as $needle) {
-            $insertPos = strpos($sql, ' ' . $needle);
+            $insertPos = strpos($sql, ' '.$needle);
 
             if ($insertPos !== false) {
                 switch ($needle) {
@@ -132,8 +132,8 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     {
         $sqls = [];
         /**
-         * @var int $i
-         * @var Varbinary $column
+         * @var int
+         * @var Column
          */
         foreach ($this->addColumns as $i => $column) {
             $sql           = $this->processExpression($column, $adapterPlatform);
@@ -145,7 +145,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
             foreach ($columnOptions as $coName => $coValue) {
                 $insert = '';
 
-                if (! $coValue) {
+                if (!$coValue) {
                     continue;
                 }
 
@@ -155,13 +155,13 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                         $j = 0;
                         break;
                     case 'collate':
-                        $insert = ' COLLATE ' . $adapterPlatform->quoteIdentifier($coValue);
+                        $insert = ' COLLATE '.$adapterPlatform->quoteIdentifier($coValue);
                         $j = 0;
                         break;
                     case 'identity':
                     case 'serial':
                     case 'autoincrement':
-                        $insert = ' IDENTITY ' . $this->normalizeIdentityOptionValue($coValue);
+                        $insert = ' IDENTITY '.$this->normalizeIdentityOptionValue($coValue);
                         $j = 0;
                         break;
                     case 'rowguidcol':
@@ -173,15 +173,15 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                         $j = 1;
                         break;
                     case 'encryptedwith':
-                        $insert = ' ENCRYPTED WITH ' . $coValue;
+                        $insert = ' ENCRYPTED WITH '.$coValue;
                         $j = 1;
                         break;
                     case 'maskedwith':
-                        $insert = ' MASKED WITH ' . $coValue;
+                        $insert = ' MASKED WITH '.$coValue;
                         $j = 1;
                         break;
                     case 'comment':
-                        $insert = ' COMMENT ' . $adapterPlatform->quoteValue($coValue);
+                        $insert = ' COMMENT '.$adapterPlatform->quoteValue($coValue);
                         $j = 2;
                         break;
                 }
@@ -197,25 +197,25 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
             }
             $sqls[] = [
                 $adapterPlatform->quoteIdentifier($this->subject->table),
-                $sql
+                $sql,
             ];
         }
 
         return [$sqls];
     }
 
-    protected function processAddConstraints(PlatformInterface $adapterPlatform = null) {
+    protected function processAddConstraints(PlatformInterface $adapterPlatform = null)
+    {
         $sqls = [];
         foreach ($this->addConstraints as $constraint) {
             $sqls[] = [
                 $adapterPlatform->quoteIdentifier($this->subject->table),
-                $this->processExpression($constraint, $adapterPlatform)
+                $this->processExpression($constraint, $adapterPlatform),
             ];
         }
 
         return [$sqls];
     }
-
 
     protected function processExpression(
         ExpressionInterface $expression,
@@ -228,27 +228,29 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
 
         // alternatively add column decorators
         // varbinary data type without length parameter
-        if($expression instanceof Varbinary && preg_match('/VARBINARY(\s)*[^\(]/', $sql) === 1) {
+        if ($expression instanceof Varbinary && preg_match('/VARBINARY(\s)*[^\(]/', $sql) === 1) {
             $sql = str_replace('VARBINARY', 'VARBINARY (max)', $sql);
         }
+
         return $sql;
     }
 
-    private function normalizeIdentityOptionValue($value) {
-        if(is_bool($value)) {
+    private function normalizeIdentityOptionValue($value)
+    {
+        if (is_bool($value)) {
             return '(1, 1)';
         }
 
         $value = trim($value);
         // if user did not use brackets for identity function parameters
         // add them.
-        if(strpos($value, '(') !== 0) {
+        if (strpos($value, '(') !== 0) {
             $value = '('.$value.')';
         }
 
         // end result should be (seed, increment)
-        if(preg_match('/\([1-9]+\,(\s)*[1-9]+\)/', $value) === 0) {
-            throw new InvalidArgumentException('Identity format should be: (seed, increment). ' .$value. ' is given instead.');
+        if (preg_match('/\([1-9]+\,(\s)*[1-9]+\)/', $value) === 0) {
+            throw new InvalidArgumentException('Identity format should be: (seed, increment). '.$value.' is given instead.');
         }
 
         return $value;
@@ -265,7 +267,6 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     }
 
     /**
-     *
      * @param string $columnA
      * @param string $columnB
      *

--- a/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
@@ -11,8 +11,13 @@
 
 namespace Zend\Db\Sql\Platform\SqlServer\Ddl;
 
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl\Column\Varbinary;
+use Zend\Db\Sql\Exception\InvalidArgumentException;
+use Zend\Db\Sql\ExpressionInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 
 class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterface
@@ -23,11 +28,50 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     protected $subject;
 
     protected $alterSpecifications = [
-        self::ADD_COLUMNS => [
+        self::ADD_COLUMNS  => [
             "%1\$s" => [
-                [1 => "ADD %1\$s,\n", 'combinedby' => ''],
-            ],
+                [2 => "ALTER TABLE %1\$s\n ADD %2\$s;", 'combinedby' => "\n"]
+            ]
         ],
+        self::CHANGE_COLUMNS  => [
+            "%1\$s" => [
+                [2 => "CHANGE COLUMN %1\$s %2\$s,\n", 'combinedby' => ""],
+            ]
+        ],
+        self::DROP_COLUMNS  => [
+            "%1\$s" => [
+                [1 => "DROP COLUMN %1\$s,\n", 'combinedby' => ""],
+            ]
+        ],
+        self::ADD_CONSTRAINTS  => [
+            "%1\$s" => [
+                [2 => "ALTER TABLE %1\$s\n ADD %2\$s;", 'combinedby' => "\n"],
+            ]
+        ],
+        self::DROP_CONSTRAINTS  => [
+            "%1\$s" => [
+                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""],
+            ]
+        ],
+    ];
+
+    private $alterTableExpression;
+
+
+    /**
+     * @var int[]
+     * https://msdn.microsoft.com/en-us/library/ms187742.aspx#Syntax
+     */
+    protected $columnOptionSortOrder = [
+        'filestream'    => 0,
+        'collate'       => 1,
+        'identity'      => 2,
+        'serial'        => 2,
+        'autoincrement' => 2,
+        'rowguidcol'    => 3,
+        'sparse'        => 4,
+        'encryptedwith' => 4,
+        'maskedwith'    => 5,
     ];
 
     /**
@@ -39,18 +83,204 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     {
         $this->subject = $subject;
         $this->specifications = array_merge($this->specifications, $this->alterSpecifications);
+        unset($this->specifications[self::TABLE]);
         $this->subject->specifications = $this->specifications;
 
         return $this;
     }
 
+
+    // SqlServer cannot have multiple operations in ALTER TABLE
+    // generate on first time, and reuse for all operations
+
+
+    /**
+     * @param string $sql
+     * @return array
+     */
+    protected function getSqlInsertOffsets($sql)
+    {
+        $sqlLength   = strlen($sql);
+        $insertStart = [];
+
+        foreach (['NOT NULL', 'NULL', 'DEFAULT', 'UNIQUE', 'PRIMARY', 'REFERENCES'] as $needle) {
+            $insertPos = strpos($sql, ' ' . $needle);
+
+            if ($insertPos !== false) {
+                switch ($needle) {
+                    case 'REFERENCES':
+                        $insertStart[2] = !isset($insertStart[2]) ? $insertPos : $insertStart[2];
+                    // no break
+                    case 'PRIMARY':
+                    case 'UNIQUE':
+                        $insertStart[1] = !isset($insertStart[1]) ? $insertPos : $insertStart[1];
+                    // no break
+                    default:
+                        $insertStart[0] = !isset($insertStart[0]) ? $insertPos : $insertStart[0];
+                }
+            }
+        }
+
+        foreach (range(0, 3) as $i) {
+            $insertStart[$i] = isset($insertStart[$i]) ? $insertStart[$i] : $sqlLength;
+        }
+
+        return $insertStart;
+    }
+
     protected function processAddColumns(PlatformInterface $adapterPlatform = null)
     {
         $sqls = [];
-        foreach ($this->addColumns as $column) {
-            $sqls[] = $this->processExpression($column, $adapterPlatform);
+        /**
+         * @var int $i
+         * @var Varbinary $column
+         */
+        foreach ($this->addColumns as $i => $column) {
+            $sql           = $this->processExpression($column, $adapterPlatform);
+            $insertStart   = $this->getSqlInsertOffsets($sql);
+            $columnOptions = $column->getOptions();
+
+            uksort($columnOptions, [$this, 'compareColumnOptions']);
+
+            foreach ($columnOptions as $coName => $coValue) {
+                $insert = '';
+
+                if (! $coValue) {
+                    continue;
+                }
+
+                switch ($this->normalizeColumnOption($coName)) {
+                    case 'filestream':
+                        $insert = ' FILESTREAM';
+                        $j = 0;
+                        break;
+                    case 'collate':
+                        $insert = ' COLLATE ' . $adapterPlatform->quoteIdentifier($coValue);
+                        $j = 0;
+                        break;
+                    case 'identity':
+                    case 'serial':
+                    case 'autoincrement':
+                        $insert = ' IDENTITY ' . $this->normalizeIdentityOptionValue($coValue);
+                        $j = 0;
+                        break;
+                    case 'rowguidcol':
+                        $insert = ' ROWGUIDCOL';
+                        $j = 1;
+                        break;
+                    case 'sparse':
+                        $insert = ' SPARSE';
+                        $j = 1;
+                        break;
+                    case 'encryptedwith':
+                        $insert = ' ENCRYPTED WITH ' . $coValue;
+                        $j = 1;
+                        break;
+                    case 'maskedwith':
+                        $insert = ' MASKED WITH ' . $coValue;
+                        $j = 1;
+                        break;
+                    case 'comment':
+                        $insert = ' COMMENT ' . $adapterPlatform->quoteValue($coValue);
+                        $j = 2;
+                        break;
+                }
+
+                if ($insert) {
+                    $j = isset($j) ? $j : 0;
+                    $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
+                    $insertStartCount = count($insertStart);
+                    for (; $j < $insertStartCount; ++$j) {
+                        $insertStart[$j] += strlen($insert);
+                    }
+                }
+            }
+            $sqls[] = [
+                $adapterPlatform->quoteIdentifier($this->subject->table),
+                $sql
+            ];
         }
 
         return [$sqls];
+    }
+
+    protected function processAddConstraints(PlatformInterface $adapterPlatform = null) {
+        $sqls = [];
+        foreach ($this->addConstraints as $constraint) {
+            $sqls[] = [
+                $adapterPlatform->quoteIdentifier($this->subject->table),
+                $this->processExpression($constraint, $adapterPlatform)
+            ];
+        }
+
+        return [$sqls];
+    }
+
+
+    protected function processExpression(
+        ExpressionInterface $expression,
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null,
+        $namedParameterPrefix = null
+    ) {
+        $sql = $this->subject->processExpression($expression, $platform, $driver, $parameterContainer, $namedParameterPrefix);
+
+        // alternatively add column decorators
+        // varbinary data type without length parameter
+        if($expression instanceof Varbinary && preg_match('/VARBINARY(\s)*[^\(]/', $sql) === 1) {
+            $sql = str_replace('VARBINARY', 'VARBINARY (max)', $sql);
+        }
+        return $sql;
+    }
+
+    private function normalizeIdentityOptionValue($value) {
+        if(is_bool($value)) {
+            return '(1, 1)';
+        }
+
+        $value = trim($value);
+        // if user did not use brackets for identity function parameters
+        // add them.
+        if(strpos($value, '(') !== 0) {
+            $value = '('.$value.')';
+        }
+
+        // end result should be (seed, increment)
+        if(preg_match('/\([1-9]+\,(\s)*[1-9]+\)/', $value) === 0) {
+            throw new InvalidArgumentException('Identity format should be: (seed, increment). ' .$value. ' is given instead.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    private function normalizeColumnOption($name)
+    {
+        return strtolower(str_replace(['-', '_', ' '], '', $name));
+    }
+
+    /**
+     *
+     * @param string $columnA
+     * @param string $columnB
+     *
+     * @return int
+     */
+    private function compareColumnOptions($columnA, $columnB)
+    {
+        $columnA = $this->normalizeColumnOption($columnA);
+        $columnA = isset($this->columnOptionSortOrder[$columnA])
+            ? $this->columnOptionSortOrder[$columnA] : count($this->columnOptionSortOrder);
+
+        $columnB = $this->normalizeColumnOption($columnB);
+        $columnB = isset($this->columnOptionSortOrder[$columnB])
+            ? $this->columnOptionSortOrder[$columnB] : count($this->columnOptionSortOrder);
+
+        return $columnA - $columnB;
     }
 }

--- a/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/AlterTableDecorator.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\SqlServer\Ddl;
+
+use Zend\Db\Adapter\Platform\PlatformInterface;
+use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+
+class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterface
+{
+    /**
+     * @var AlterTable
+     */
+    protected $subject;
+
+    protected $alterSpecifications = [
+        self::ADD_COLUMNS => [
+            "%1\$s" => [
+                [1 => "ADD %1\$s,\n", 'combinedby' => ''],
+            ],
+        ],
+    ];
+
+    /**
+     * @param AlterTable $subject
+     *
+     * @return self
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        $this->specifications = array_merge($this->specifications, $this->alterSpecifications);
+        $this->subject->specifications = $this->specifications;
+
+        return $this;
+    }
+
+    protected function processAddColumns(PlatformInterface $adapterPlatform = null)
+    {
+        $sqls = [];
+        foreach ($this->addColumns as $column) {
+            $sqls[] = $this->processExpression($column, $adapterPlatform);
+        }
+
+        return [$sqls];
+    }
+}

--- a/src/Sql/Platform/SqlServer/SqlServer.php
+++ b/src/Sql/Platform/SqlServer/SqlServer.php
@@ -17,5 +17,6 @@ class SqlServer extends AbstractPlatform
     {
         $this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
         $this->setTypeDecorator('Zend\Db\Sql\Ddl\CreateTable', new Ddl\CreateTableDecorator());
+        $this->setTypeDecorator('Zend\Db\Sql\Ddl\AlterTable', new Ddl\AlterTableDecorator());
     }
 }

--- a/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
@@ -38,5 +38,13 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
                 ' ADD [id] INTEGER NOT NULL PRIMARY KEY',
             $ctd->setSubject($ct)->getSqlString($platform)
         );
+
+        $ct = new AlterTable('constrained');
+        $ct->addConstraint(new PrimaryKey(['u_id', 'g_id'], 'UserGroup_PK'));
+        $this->assertEquals(
+            "ALTER TABLE [constrained]\n".
+                '    ADD CONSTRAINT [UserGroup_PK] PRIMARY KEY ([u_id], [g_id])',
+            $ctd->setSubject($ct)->getSqlString($platform)
+        );
     }
 }

--- a/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
@@ -28,8 +28,8 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $platform = new TrustingSqlServerPlatform();
 
-        $ctd = new AlterTableDecorator();
-        $ct = new AlterTable('altered');
+        $atd = new AlterTableDecorator();
+        $at = new AlterTable('altered');
 
         // test for valid syntax, not valid engine semantics
         $id = new Column('id');
@@ -41,27 +41,27 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $id->setOption('encrypted with', '(COLUMN_ENCRYPTION_KEY = key_name)');
         $id->setOption('masked with', "(FUNCTION = ' mask_function ')");
         $id->setOption('identity', '(1, 1)');
-        $ct->addColumn($id);
+        $at->addColumn($id);
 
         $pk = new Column('named_pk');
         $pk->addConstraint(new PrimaryKey(null, 'specified_pk'));
-        $ct->addColumn($pk);
+        $at->addColumn($pk);
 
         $this->assertEquals(
             "ALTER TABLE [altered]\n".
                 " ADD [id] INTEGER FILESTREAM COLLATE [Cyrillic_General_CI_AS] IDENTITY (1, 1) NOT NULL ROWGUIDCOL SPARSE ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = key_name) MASKED WITH (FUNCTION = ' mask_function ') PRIMARY KEY;\n".
             "ALTER TABLE [altered]\n".
-                " ADD [named_pk] INTEGER NOT NULL CONSTRAINT [specified_pk] PRIMARY KEY;",
-            $ctd->setSubject($ct)->getSqlString($platform)
+                ' ADD [named_pk] INTEGER NOT NULL CONSTRAINT [specified_pk] PRIMARY KEY;',
+            $atd->setSubject($at)->getSqlString($platform)
         );
 
         // add constraint without columns
-        $ct = new AlterTable('constrained');
-        $ct->addConstraint(new PrimaryKey(['u_id', 'g_id'], 'UserGroup_PK'));
+        $at = new AlterTable('constrained');
+        $at->addConstraint(new PrimaryKey(['u_id', 'g_id'], 'UserGroup_PK'));
         $this->assertEquals(
             "ALTER TABLE [constrained]\n".
                 ' ADD CONSTRAINT [UserGroup_PK] PRIMARY KEY ([u_id], [g_id]);',
-            trim($ctd->setSubject($ct)->getSqlString($platform))
+            trim($atd->setSubject($at)->getSqlString($platform))
         );
     }
 
@@ -69,16 +69,16 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $platform = new TrustingSqlServerPlatform();
 
-        $ctd = new AlterTableDecorator();
-        $ct = new AlterTable('identifiable');
+        $atd = new AlterTableDecorator();
+        $at = new AlterTable('identifiable');
         $id = new Column('id');
         $id->setOption('identity', true);
-        $ct->addColumn($id);
+        $at->addColumn($id);
 
         $this->assertEquals(
             "ALTER TABLE [identifiable]\n".
                 ' ADD [id] INTEGER IDENTITY (1, 1) NOT NULL;',
-            $ctd->setSubject($ct)->getSqlString($platform)
+            $atd->setSubject($at)->getSqlString($platform)
         );
     }
 
@@ -86,29 +86,29 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $platform = new TrustingSqlServerPlatform();
 
-        $ctd = new AlterTableDecorator();
-        $ct = new AlterTable('invalid');
+        $atd = new AlterTableDecorator();
+        $at = new AlterTable('invalid');
 
         $id = new Column('id');
         $id->setOption('identity', '1');
-        $ct->addColumn($id);
+        $at->addColumn($id);
 
         $this->setExpectedException(InvalidArgumentException::class);
-        $ctd->setSubject($ct)->getSqlString($platform);
+        $atd->setSubject($at)->getSqlString($platform);
     }
 
     public function testVarbinarySyntaxCorrected()
     {
         $platform = new TrustingSqlServerPlatform();
 
-        $ctd = new AlterTableDecorator();
-        $ct = new AlterTable('hasbinarydata');
+        $atd = new AlterTableDecorator();
+        $at = new AlterTable('hasbinarydata');
 
-        $ct->addColumn(new Varbinary('binary'));
+        $at->addColumn(new Varbinary('binary'));
         $this->assertEquals(
             "ALTER TABLE [hasbinarydata]\n".
                 ' ADD [binary] VARBINARY (max) NOT NULL;',
-            $ctd->setSubject($ct)->getSqlString($platform)
+            $atd->setSubject($at)->getSqlString($platform)
         );
     }
 }

--- a/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
@@ -5,7 +5,7 @@
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  *
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -13,7 +13,9 @@ namespace ZendTest\Db\Sql\Platform\SqlServer\Ddl;
 
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column\Column;
+use Zend\Db\Sql\Ddl\Column\Varbinary;
 use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
+use Zend\Db\Sql\Exception\InvalidArgumentException;
 use Zend\Db\Sql\Platform\Sqlserver\Ddl\AlterTableDecorator;
 use ZendTest\Db\TestAsset\TrustingSqlServerPlatform;
 
@@ -27,23 +29,85 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $platform = new TrustingSqlServerPlatform();
 
         $ctd = new AlterTableDecorator();
-
         $ct = new AlterTable('altered');
 
+        // test for valid syntax, not valid engine semantics
         $id = new Column('id');
         $id->addConstraint(new PrimaryKey());
+        $id->setOption('filestream', true);
+        $id->setOption('collate', 'Cyrillic_General_CI_AS');
+        $id->setOption('rowguidcol', true);
+        $id->setOption('sparse', true);
+        $id->setOption('encrypted with', '(COLUMN_ENCRYPTION_KEY = key_name)');
+        $id->setOption('masked with', "(FUNCTION = ' mask_function ')");
+        $id->setOption('identity', '(1, 1)');
         $ct->addColumn($id);
+
+        $pk = new Column('named_pk');
+        $pk->addConstraint(new PrimaryKey(null, 'specified_pk'));
+        $ct->addColumn($pk);
+
         $this->assertEquals(
             "ALTER TABLE [altered]\n".
-                ' ADD [id] INTEGER NOT NULL PRIMARY KEY',
+                " ADD [id] INTEGER FILESTREAM COLLATE [Cyrillic_General_CI_AS] IDENTITY (1, 1) NOT NULL ROWGUIDCOL SPARSE ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = key_name) MASKED WITH (FUNCTION = ' mask_function ') PRIMARY KEY;\n".
+            "ALTER TABLE [altered]\n".
+                " ADD [named_pk] INTEGER NOT NULL CONSTRAINT [specified_pk] PRIMARY KEY;",
             $ctd->setSubject($ct)->getSqlString($platform)
         );
 
+        // add constraint without columns
         $ct = new AlterTable('constrained');
         $ct->addConstraint(new PrimaryKey(['u_id', 'g_id'], 'UserGroup_PK'));
         $this->assertEquals(
             "ALTER TABLE [constrained]\n".
-                '    ADD CONSTRAINT [UserGroup_PK] PRIMARY KEY ([u_id], [g_id])',
+                ' ADD CONSTRAINT [UserGroup_PK] PRIMARY KEY ([u_id], [g_id]);',
+            trim($ctd->setSubject($ct)->getSqlString($platform))
+        );
+    }
+
+    public function testIdentityBooleanConvertsToDefaultParams()
+    {
+        $platform = new TrustingSqlServerPlatform();
+
+        $ctd = new AlterTableDecorator();
+        $ct = new AlterTable('identifiable');
+        $id = new Column('id');
+        $id->setOption('identity', true);
+        $ct->addColumn($id);
+
+        $this->assertEquals(
+            "ALTER TABLE [identifiable]\n".
+                ' ADD [id] INTEGER IDENTITY (1, 1) NOT NULL;',
+            $ctd->setSubject($ct)->getSqlString($platform)
+        );
+    }
+
+    public function testIdentityInvalidFormatThrowsException()
+    {
+        $platform = new TrustingSqlServerPlatform();
+
+        $ctd = new AlterTableDecorator();
+        $ct = new AlterTable('invalid');
+
+        $id = new Column('id');
+        $id->setOption('identity', '1');
+        $ct->addColumn($id);
+
+        $this->setExpectedException(InvalidArgumentException::class);
+        $ctd->setSubject($ct)->getSqlString($platform);
+    }
+
+    public function testVarbinarySyntaxCorrected()
+    {
+        $platform = new TrustingSqlServerPlatform();
+
+        $ctd = new AlterTableDecorator();
+        $ct = new AlterTable('hasbinarydata');
+
+        $ct->addColumn(new Varbinary('binary'));
+        $this->assertEquals(
+            "ALTER TABLE [hasbinarydata]\n".
+                ' ADD [binary] VARBINARY (max) NOT NULL;',
             $ctd->setSubject($ct)->getSqlString($platform)
         );
     }

--- a/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
@@ -13,7 +13,8 @@ namespace ZendTest\Db\Sql\Platform\SqlServer\Ddl;
 
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column\Column;
-use Zend\Db\Sql\Platform\SqlServer\Ddl\AlterTableDecorator;
+use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
+use Zend\Db\Sql\Platform\Sqlserver\Ddl\AlterTableDecorator;
 use ZendTest\Db\TestAsset\TrustingSqlServerPlatform;
 
 class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
@@ -28,10 +29,13 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $ctd = new AlterTableDecorator();
 
         $ct = new AlterTable('altered');
-        $ct->addColumn(new Column('addedColumn'));
+
+        $id = new Column('id');
+        $id->addConstraint(new PrimaryKey());
+        $ct->addColumn($id);
         $this->assertEquals(
             "ALTER TABLE [altered]\n".
-                ' ADD [addedColumn] INTEGER NOT NULL',
+                ' ADD [id] INTEGER NOT NULL PRIMARY KEY',
             $ctd->setSubject($ct)->getSqlString($platform)
         );
     }

--- a/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/AlterTableDecoratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ *
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform\SqlServer\Ddl;
+
+use Zend\Db\Sql\Ddl\AlterTable;
+use Zend\Db\Sql\Ddl\Column\Column;
+use Zend\Db\Sql\Platform\SqlServer\Ddl\AlterTableDecorator;
+use ZendTest\Db\TestAsset\TrustingSqlServerPlatform;
+
+class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Zend\Db\Sql\Platform\SqlServer\Ddl\AlterTableDecorator::getSqlString
+     */
+    public function testGetSqlString()
+    {
+        $platform = new TrustingSqlServerPlatform();
+
+        $ctd = new AlterTableDecorator();
+
+        $ct = new AlterTable('altered');
+        $ct->addColumn(new Column('addedColumn'));
+        $this->assertEquals(
+            "ALTER TABLE [altered]\n".
+                ' ADD [addedColumn] INTEGER NOT NULL',
+            $ctd->setSubject($ct)->getSqlString($platform)
+        );
+    }
+}

--- a/test/Sql/Platform/SqlServer/Ddl/CreateTableDecoratorTest.php
+++ b/test/Sql/Platform/SqlServer/Ddl/CreateTableDecoratorTest.php
@@ -1,17 +1,21 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ *
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Db\Sql\Platform\SqlServer\Ddl;
 
+use Zend\Db\Sql\Ddl\Column\Column;
+use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
 use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\SqlServer\Ddl\CreateTableDecorator;
-use Zend\Db\Sql\Ddl\Column\Column;
+use ZendTest\Db\TestAsset\TrustingSqlServerPlatform;
 
 class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,20 +24,47 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSqlString()
     {
+        $platform = new TrustingSqlServerPlatform();
+
         $ctd = new CreateTableDecorator();
 
         $ct = new CreateTable('foo');
-        $this->assertEquals("CREATE TABLE \"foo\" ( \n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE [foo] ( \n     \n)", $ctd->setSubject($ct)->getSqlString($platform));
 
         $ct = new CreateTable('foo', true);
-        $this->assertEquals("CREATE TABLE \"#foo\" ( \n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE [#foo] ( \n     \n)", $ctd->setSubject($ct)->getSqlString($platform));
 
         $ct = new CreateTable('foo');
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE [foo] ( \n    [bar] INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString($platform));
 
         $ct = new CreateTable('foo', true);
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TABLE \"#foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE [#foo] ( \n    [bar] INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString($platform));
+
+        $ct = new CreateTable('opinionated');
+        // test for valid syntax, not valid engine semantics
+        $id = new Column('id');
+        $id->addConstraint(new PrimaryKey());
+        $id->setOption('filestream', true);
+        $id->setOption('collate', 'Cyrillic_General_CI_AS');
+        $id->setOption('rowguidcol', true);
+        $id->setOption('sparse', true);
+        $id->setOption('encrypted with', '(COLUMN_ENCRYPTION_KEY = key_name)');
+        $id->setOption('masked with', "(FUNCTION = ' mask_function ')");
+        $id->setOption('identity', '(1, 1)');
+        $ct->addColumn($id);
+
+        $pk = new Column('named_pk');
+        $pk->addConstraint(new PrimaryKey(null, 'specified_pk'));
+        $ct->addColumn($pk);
+
+        $this->assertEquals(
+            "CREATE TABLE [opinionated] ( \n".
+            "    [id] INTEGER FILESTREAM COLLATE [Cyrillic_General_CI_AS] IDENTITY (1, 1) NOT NULL ROWGUIDCOL SPARSE ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = key_name) MASKED WITH (FUNCTION = ' mask_function ') PRIMARY KEY,\n".
+            "    [named_pk] INTEGER NOT NULL CONSTRAINT [specified_pk] PRIMARY KEY \n".
+            ')',
+            $ctd->setSubject($ct)->getSqlString($platform)
+        );
     }
 }


### PR DESCRIPTION
#215, #214 as starting points plus everything else

- [ ] CreateTable
  - [ ] Column options as outlined in https://msdn.microsoft.com/en-us/library/ms187742.aspx#Syntax
  - [ ] Test constraint variations
- [ ] AlterTable
  - [ ] add columns
  - [ ] add constraints
  - [ ] change columns
  - [ ] drop columns
  - [ ] drop constraints

I am following existing style of specification compilation to make code reviewer easier, even though it is extremely repetitive, eg. altertable decorator vs createtable decorator. I assume maintainers would have already gotten used to looking at current structure, plus current style is known to work and I do not want to add extra uncertainty of reorganizing inheritance hierarchy on top of trying to get syntax correct.

Current DDL implementation is extremely MySQL biased - feels like it is Zend MySql instead of Zend DB so this project will take some time to complete and will be a large code review. Therefore, probably won't make it next release but still want to show that I am not slacking off too much.