### PR TITLE
TableIdentifier schema parameter to allow arrays for use in quoteIdentifierChain to express full object path.

### DIFF
--- a/doc/book/sql.md
+++ b/doc/book/sql.md
@@ -151,6 +151,11 @@ $select->from(['t' => 'table']);
 // Using a Sql\TableIdentifier:
 // (same output as above)
 $select->from(new TableIdentifier(['t' => 'table']));
+
+// If your database engine requires full path to get to the table object,
+// for example SQL Server uses database name as part of the table name,
+// pass the schema path to the second parameter
+$select->from(new TableIdentifier('table', ['dbo', 'schema']));
 ```
 
 ### columns()

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -12,8 +12,8 @@ namespace Zend\Db\Sql;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Adapter\Platform\Sql92 as DefaultAdapterPlatform;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 
 abstract class AbstractSql implements SqlInterface
 {
@@ -435,7 +435,7 @@ abstract class AbstractSql implements SqlInterface
         }
 
         if ($schema && $table) {
-            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+            $table = $platform->quoteIdentifierChain($schema).$platform->getIdentifierSeparator() . $table;
         }
         return $table;
     }

--- a/src/Sql/TableIdentifier.php
+++ b/src/Sql/TableIdentifier.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ *
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -19,17 +21,17 @@ class TableIdentifier
     protected $table;
 
     /**
-     * @var null|string
+     * @var null|string|array
      */
     protected $schema;
 
     /**
-     * @param string      $table
-     * @param null|string $schema
+     * @param string            $table
+     * @param null|string|array $schema
      */
     public function __construct($table, $schema = null)
     {
-        if (! (is_string($table) || is_callable([$table, '__toString']))) {
+        if (!(is_string($table) || is_callable([$table, '__toString']))) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$table must be a valid table name, parameter of type %s given',
                 is_object($table) ? get_class($table) : gettype($table)
@@ -45,14 +47,17 @@ class TableIdentifier
         if (null === $schema) {
             $this->schema = null;
         } else {
-            if (! (is_string($schema) || is_callable([$schema, '__toString']))) {
+            if (!(is_string($schema) || is_array($schema) || is_callable([$schema, '__toString']))) {
                 throw new Exception\InvalidArgumentException(sprintf(
-                    '$schema must be a valid schema name, parameter of type %s given',
+                    '$schema must be a valid schema name or path in form of array, parameter of type %s given',
                     is_object($schema) ? get_class($schema) : gettype($schema)
                 ));
             }
 
-            $this->schema = (string) $schema;
+            if (!is_array($schema)) {
+                $schema = (string) $schema;
+            }
+            $this->schema = $schema;
 
             if ('' === $this->schema) {
                 throw new Exception\InvalidArgumentException(

--- a/test/Sql/TableIdentifierTest.php
+++ b/test/Sql/TableIdentifierTest.php
@@ -1,19 +1,23 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ *
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Db\Sql;
 
 use stdClass;
+use Zend\Db\Sql\Select;
 use Zend\Db\Sql\TableIdentifier;
+use ZendTest\Db\TestAsset\TrustingSql92Platform;
 
 /**
- * Tests for {@see \Zend\Db\Sql\TableIdentifier}
+ * Tests for {@see \Zend\Db\Sql\TableIdentifier}.
  *
  * @covers \Zend\Db\Sql\TableIdentifier
  */
@@ -88,8 +92,18 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
         new TableIdentifier('foo', $invalidSchema);
     }
 
+    public function testSchemaPath()
+    {
+        $select = new Select(new TableIdentifier('table', ['db', 'schema']));
+
+        $this->assertEquals(
+            'SELECT "db"."schema"."table".* FROM "db"."schema"."table"',
+            $select->getSqlString(new TrustingSql92Platform())
+        );
+    }
+
     /**
-     * Data provider
+     * Data provider.
      *
      * @return mixed[][]
      */
@@ -102,7 +116,7 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Data provider
+     * Data provider.
      *
      * @return mixed[][]
      */
@@ -111,7 +125,6 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
         return [
             [''],
             [new stdClass()],
-            [[]],
         ];
     }
 }


### PR DESCRIPTION
#206 Allow expression of full path towards table by allowing array as parameter for $schema in TableIdentifier and use `quoteIdentifierChain` in Sql table resolver. Reasoning explained in the issue.

While working on this noticed that `quoteIdentifierChain` tries to preform near identical operation as `identifierChain`, hence the change in the `AbstractSQL` class, but in less safer way. The result is the same most of the time but it uses hardcoded strings, instead of tokens specified in the specification that `quoteIdentifier` is using, such as `quoteIdentiferTo` or `quoteIdentifer[0]` and `getIdentifierSeparator()`.

Cleaning that up possibly in another PR.