### PR TITLE
Delegate quoteIdentifier operation to quoteIdentifierChain

### DIFF
--- a/src/Adapter/Platform/AbstractPlatform.php
+++ b/src/Adapter/Platform/AbstractPlatform.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
- * Zend Framework (http://framework.zend.com/)
+ * Zend Framework (http://framework.zend.com/).
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ *
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -31,7 +33,7 @@ abstract class AbstractPlatform implements PlatformInterface
      */
     public function quoteIdentifierInFragment($identifier, array $safeWords = [])
     {
-        if (! $this->quoteIdentifiers) {
+        if (!$this->quoteIdentifiers) {
             return $identifier;
         }
 
@@ -54,8 +56,8 @@ abstract class AbstractPlatform implements PlatformInterface
             $identifier .= isset($safeWordsInt[strtolower($part)])
                 ? $part
                 : $this->quoteIdentifier[0]
-                . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $part)
-                . $this->quoteIdentifier[1];
+                .str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $part)
+                .$this->quoteIdentifier[1];
         }
 
         return $identifier;
@@ -66,13 +68,7 @@ abstract class AbstractPlatform implements PlatformInterface
      */
     public function quoteIdentifier($identifier)
     {
-        if (! $this->quoteIdentifiers) {
-            return $identifier;
-        }
-
-        return $this->quoteIdentifier[0]
-            . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $identifier)
-            . $this->quoteIdentifier[1];
+        return $this->quoteIdentifierChain([$identifier]);
     }
 
     /**
@@ -80,7 +76,21 @@ abstract class AbstractPlatform implements PlatformInterface
      */
     public function quoteIdentifierChain($identifierChain)
     {
-        return '"' . implode('"."', (array) str_replace('"', '\\"', $identifierChain)) . '"';
+        if (is_string($identifierChain)) {
+            $identifierChain = [$identifierChain];
+        }
+
+        if (!$this->quoteIdentifiers) {
+            return implode($this->getIdentifierSeparator(), $identifierChain);
+        }
+
+        /** @var array $identifierChain */
+        foreach ($identifierChain as $key => $identifier) {
+            $identifierChain[$key] = str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $identifier);
+        }
+        $chainGlue = $this->quoteIdentifier[1].$this->getIdentifierSeparator().$this->quoteIdentifier[0];
+
+        return $this->quoteIdentifier[0].implode($chainGlue, $identifierChain).$this->quoteIdentifier[1];
     }
 
     /**
@@ -105,10 +115,11 @@ abstract class AbstractPlatform implements PlatformInterface
     public function quoteValue($value)
     {
         trigger_error(
-            'Attempting to quote a value in ' . get_class($this) .
+            'Attempting to quote a value in '.get_class($this).
             ' without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        return '\'' . addcslashes((string) $value, "\x00\n\r\\'\"\x1a") . '\'';
+
+        return '\''.addcslashes((string) $value, "\x00\n\r\\'\"\x1a").'\'';
     }
 
     /**
@@ -116,7 +127,7 @@ abstract class AbstractPlatform implements PlatformInterface
      */
     public function quoteTrustedValue($value)
     {
-        return '\'' . addcslashes((string) $value, "\x00\n\r\\'\"\x1a") . '\'';
+        return '\''.addcslashes((string) $value, "\x00\n\r\\'\"\x1a").'\'';
     }
 
     /**

--- a/src/Adapter/Platform/Mysql.php
+++ b/src/Adapter/Platform/Mysql.php
@@ -72,14 +72,6 @@ class Mysql extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        return '`' . implode('`.`', (array) str_replace('`', '``', $identifierChain)) . '`';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {

--- a/src/Adapter/Platform/Oracle.php
+++ b/src/Adapter/Platform/Oracle.php
@@ -12,7 +12,7 @@ namespace Zend\Db\Adapter\Platform;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Oci8\Oci8;
 use Zend\Db\Adapter\Driver\Pdo\Pdo;
-use \Zend\Db\Adapter\Exception\InvalidArgumentException;
+use Zend\Db\Adapter\Exception\InvalidArgumentException;
 
 class Oracle extends AbstractPlatform
 {
@@ -76,18 +76,6 @@ class Oracle extends AbstractPlatform
     public function getName()
     {
         return 'Oracle';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        if ($this->quoteIdentifiers === false) {
-            return implode('.', (array) $identifierChain);
-        }
-
-        return '"' . implode('"."', (array) str_replace('"', '\\"', $identifierChain)) . '"';
     }
 
     /**

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -68,14 +68,6 @@ class Postgresql extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        return '"' . implode('"."', (array) str_replace('"', '""', $identifierChain)) . '"';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {

--- a/src/Adapter/Platform/SqlServer.php
+++ b/src/Adapter/Platform/SqlServer.php
@@ -77,14 +77,6 @@ class SqlServer extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        return '[' . implode('].[', (array) $identifierChain) . ']';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -12,8 +12,8 @@ namespace Zend\Db\Sql;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Adapter\Platform\Sql92 as DefaultAdapterPlatform;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 
 abstract class AbstractSql implements SqlInterface
 {
@@ -435,7 +435,7 @@ abstract class AbstractSql implements SqlInterface
         }
 
         if ($schema && $table) {
-            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+            $table = $platform->quoteIdentifierChain($schema) . $platform->getIdentifierSeparator() . $table;
         }
         return $table;
     }


### PR DESCRIPTION
Clean up identifier quoting.  quoteIdentifierChain was doing the same thing quoteIdentifier was doing but without safety of using predefined escape tokens. In turn, quoteIdentifier was producing same result as quoteIdentifierChain by adding quotes around the token, which can be simplified by immediately converting identifier to array, pass it to identiferChain, and achieve same result.  Overriding is now necessary only if there are really different rules by the engine. Eg. DB2 seems to be doing something very different.

This will help a lot with consistency in DB engines that have multiple identifiers in the path of a database objects. Eg. PostgreSQL always has trouble between choosing identifier vs chain. This can potentially solve a good portion of bad syntax generation for them.   Could consider deprecating one of them.