### PR TITLE
fixing params binding during statement execution

### DIFF
--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -269,7 +269,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     protected function bindParametersFromContainer()
     {
-        $parameters = $this->parameterContainer->getNamedArray();
+        //params by link
+        $parameters = &$this->parameterContainer->getNamedArray();
 
         foreach ($parameters as $name => &$value) {
             if ($this->parameterContainer->offsetHasErrata($name)) {

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -317,7 +317,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      *
      * @return array
      */
-    public function getNamedArray()
+    public function &getNamedArray()
     {
         return $this->data;
     }


### PR DESCRIPTION
fixing of the [issue](https://github.com/zendframework/zend-db/issues/235).

```
use Zend\Db\Adapter\Adapter;
use Zend\Db\Adapter\ParameterContainer;

$query = "BEGIN :xml := xml_builder.get_mega_simple_xml(:p_param);END;";
$pc = new ParameterContainer();
$pc->offsetSet('p_param', 123);
$pc->offsetSet('xml', '');

$adapter = new Adapter([
    'driver'   => 'Oci8',
    'connection' => 'bxconn',
    'username' => 'developer',
    'password' => 'developer-password',
    'host' => 'localhost',
    'port' => '1521',
    'charset' => 'AL32UTF8',
]);
$stmt = $adapter->createStatement();
$result = $stmt->setSql($query)
                    ->prepare()
                    ->setParameterContainer($pc)
                    ->execute();

//now i can fetch resulting xml
$resultingXML = $pc['xml'];
```