### PR TITLE
AdapterServiceFactory looks for $requestedName in db config

### DIFF
--- a/src/Adapter/AdapterServiceFactory.php
+++ b/src/Adapter/AdapterServiceFactory.php
@@ -25,8 +25,13 @@ class AdapterServiceFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $container->get('config');
-        return new Adapter($config['db']);
+        $config = $container->get('config')['db'];
+
+        if (isset($config[$requestedName])) {
+            $config = $config[$requestedName];
+        }
+
+        return new Adapter($config);
     }
 
     /**

--- a/test/Adapter/AdapterServiceFactoryTest.php
+++ b/test/Adapter/AdapterServiceFactoryTest.php
@@ -54,4 +54,19 @@ class AdapterServiceFactoryTest extends TestCase
         $adapter = $this->factory->__invoke($this->services->reveal(), Adapter::class);
         $this->assertInstanceOf(Adapter::class, $adapter);
     }
+
+    public function testV3FactoryWithRequestedNameReturnsAdapter()
+    {
+        $this->services->get('config')->willReturn([
+            'db' => [
+                Adapter::class => [
+                    'driver' => 'Pdo_Sqlite',
+                    'database' => 'sqlite::memory:',
+                ],
+            ],
+        ]);
+
+        $adapter = $this->factory->__invoke($this->services->reveal(), Adapter::class);
+        $this->assertInstanceOf(Adapter::class, $adapter);
+    }
 }


### PR DESCRIPTION
Adds possibility to have more adapters options in db config. No need to use AbstractFactory.

Example:

```
return [
    'db' => [
        'db_adapter1' => [/*...*/],
        'db_adapter2' => [/*...*/],
    ],
    'dependencies' => [
        'factories' => [
            'db_adapter1' => Zend\Db\Adapter\AdapterServiceFactory::class,
            'db_adapter2' => Zend\Db\Adapter\AdapterServiceFactory::class,
        ],
    ],
]
```
