### PR TITLE
Fix AlterTable::dropConstraint() by allowing the use of decorator

### DIFF
--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\Sql\Ddl;
 
 use Zend\Db\Adapter\Platform\PlatformInterface;
+use Zend\Db\Metadata\Object\ConstraintObject;
 use Zend\Db\Sql\AbstractSql;
 
 class AlterTable extends AbstractSql implements SqlInterface
@@ -27,7 +28,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     protected $addColumns = [];
 
     /**
-     * @var array
+     * @var Constraint\ConstraintInterface[]
      */
     protected $addConstraints = [];
 
@@ -42,7 +43,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     protected $dropColumns = [];
 
     /**
-     * @var array
+     * @var ConstraintObject[]
      */
     protected $dropConstraints = [];
 
@@ -74,7 +75,7 @@ class AlterTable extends AbstractSql implements SqlInterface
         ],
         self::DROP_CONSTRAINTS  => [
             "%1\$s" => [
-                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""],
+                [2 => "DROP %1\$s %2\$s,\n", 'combinedby' => ""],
             ]
         ]
     ];
@@ -138,12 +139,12 @@ class AlterTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @param  string $name
+     * @param  ConstraintObject $constraint
      * @return self Provides a fluent interface
      */
-    public function dropConstraint($name)
+    public function dropConstraint(ConstraintObject $constraint)
     {
-        $this->dropConstraints[] = $name;
+        $this->dropConstraints[] = $constraint;
 
         return $this;
     }
@@ -229,7 +230,10 @@ class AlterTable extends AbstractSql implements SqlInterface
     {
         $sqls = [];
         foreach ($this->dropConstraints as $constraint) {
-            $sqls[] = $adapterPlatform->quoteIdentifier($constraint);
+            $sqls[] = [
+                'CONSTRAINT',
+                $adapterPlatform->quoteIdentifier($constraint->getName())
+            ];
         }
 
         return [$sqls];

--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -248,4 +248,17 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
 
         return $columnA - $columnB;
     }
+
+    protected function processDropConstraints(PlatformInterface $adapterPlatform = null)
+    {
+        $sqls = [];
+        foreach ($this->dropConstraints as $constraint) {
+            $sqls[] = [
+                $constraint->getType(),
+                $adapterPlatform->quoteIdentifier($constraint->getName())
+            ];
+        }
+
+        return [$sqls];
+    }
 }

--- a/test/Sql/Ddl/AlterTableTest.php
+++ b/test/Sql/Ddl/AlterTableTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Db\Sql\Ddl;
 
+use Zend\Db\Metadata\Object\ConstraintObject;
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column;
 use Zend\Db\Sql\Ddl\Constraint;
@@ -66,8 +67,9 @@ class AlterTableTest extends \PHPUnit_Framework_TestCase
     public function testDropConstraint()
     {
         $at = new AlterTable();
-        $this->assertSame($at, $at->dropConstraint('foo'));
-        $this->assertEquals(['foo'], $at->getRawState($at::DROP_CONSTRAINTS));
+        $constraint = new ConstraintObject('foo', null);
+        $this->assertSame($at, $at->dropConstraint($constraint));
+        $this->assertEquals([$constraint], $at->getRawState($at::DROP_CONSTRAINTS));
     }
 
     /**
@@ -93,7 +95,7 @@ class AlterTableTest extends \PHPUnit_Framework_TestCase
         $at->changeColumn('name', new Column\Varchar('new_name', 50));
         $at->dropColumn('foo');
         $at->addConstraint(new Constraint\ForeignKey('my_fk', 'other_id', 'other_table', 'id', 'CASCADE', 'CASCADE'));
-        $at->dropConstraint('my_index');
+        $at->dropConstraint(new ConstraintObject('my_index', null));
         $expected =<<<EOS
 ALTER TABLE "foo"
  ADD COLUMN "another" VARCHAR(255) NOT NULL,

--- a/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
+++ b/test/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Db\Sql\Platform\Mysql\Ddl;
 
 use Zend\Db\Adapter\Platform\Mysql;
+use Zend\Db\Metadata\Object\ConstraintObject;
 use Zend\Db\Sql\Ddl\AlterTable;
 use Zend\Db\Sql\Ddl\Column\Column;
 use Zend\Db\Sql\Ddl\Constraint\PrimaryKey;
@@ -45,8 +46,13 @@ class AlterTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $col->addConstraint(new PrimaryKey());
         $ct->addColumn($col);
 
+        $fk = new ConstraintObject('my_fk', null);
+        $fk->setType('FOREIGN KEY');
+        $ct->dropConstraint($fk);
+
         $this->assertEquals(
-            "ALTER TABLE `foo`\n ADD COLUMN `bar` INTEGER UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'baz' AFTER `bar`",
+            "ALTER TABLE `foo`\n ADD COLUMN `bar` INTEGER UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'baz' AFTER `bar`,\n"
+            ."    DROP FOREIGN KEY `my_fk`",
             @$ctd->getSqlString(new Mysql())
         );
     }


### PR DESCRIPTION
Fixes a broken implementation under MySQL.

See issue #36 

**Warning:** introduces a potential breaking change (string parameter is now a typed object).