### PR TITLE
Allow column names to contain any character

### DIFF
--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -14,6 +14,7 @@ use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Adapter\Platform\Sql92 as DefaultAdapterPlatform;
+use Zend\Db\Exception\RuntimeException;
 
 abstract class AbstractSql implements SqlInterface
 {

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -409,8 +409,15 @@ abstract class AbstractSql implements SqlInterface
 
         if ($isIdentifier) {
             $matches = [];
-            preg_match('#(?P<column>[^\s].+?)(?:\s*$|(?:\s+as\s+(?P<alias>.*(?:\S))))#i', $column, $matches);
-            if (array_key_exists('column', $matches)) {
+            preg_match(
+                '#(?P<star>\.{0,1}\*(?=\s*$))|(?P<column>[^\s].+?)(?:\s*$|(?:\s+as\s+(?P<alias>.*(?:\S))))#i',
+                $column,
+                $matches
+            );
+            if (Select::SQL_STAR === $matches['star']) {
+                return $fromTable . Select::SQL_STAR;
+            }
+            if (array_key_exists('column', $matches) && !empty($matches['column'])) {
                 $column = $platform->quoteIdentifier($matches['column']);
                 if (array_key_exists('alias', $matches)) {
                     $column .= ' AS ' . $platform->quoteIdentifier($matches['alias']);

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -405,9 +405,21 @@ abstract class AbstractSql implements SqlInterface
         if ($column === null) {
             return 'NULL';
         }
-        return $isIdentifier
-                ? $fromTable . $platform->quoteIdentifierInFragment($column)
-                : $platform->quoteValue($column);
+
+        if ($isIdentifier) {
+            $matches = [];
+            preg_match('#(?P<column>[^\s].+?)(?:\s*$|(?:\s+as\s+(?P<alias>.*(?:\S))))#i', $column, $matches);
+            if (array_key_exists('column', $matches)) {
+                $column = $platform->quoteIdentifier($matches['column']);
+                if (array_key_exists('alias', $matches)) {
+                    $column .= ' AS ' . $platform->quoteIdentifier($matches['alias']);
+                }
+                return $fromTable . $column;
+            }
+            throw new RuntimeException('Invalid column name');
+        }
+
+        return $platform->quoteValue($column);
     }
 
     /**

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -410,10 +410,13 @@ abstract class AbstractSql implements SqlInterface
         if ($isIdentifier) {
             $matches = [];
             preg_match(
-                '#(?P<star>\.{0,1}\*(?=\s*$))|(?P<column>[^\s].+?)(?:\s*$|(?:\s+as\s+(?P<alias>.*(?:\S))))#i',
+                '#(?:(?<table>[^\s].*?)\.(?=\S)){0,1}(?:(?<star>\.{0,1}\*(?=\s*$))|(?<column>[^\s].*?)(?:\s*$|(?:\s+as\s+(?<alias>.*(?:\S)))))#i',
                 $column,
                 $matches
             );
+            if (!empty($matches['table'])) {
+                $fromTable = $platform->quoteIdentifier($matches['table']) . $platform->getIdentifierSeparator();
+            }
             if (Select::SQL_STAR === $matches['star']) {
                 return $fromTable . Select::SQL_STAR;
             }


### PR DESCRIPTION
In regards to issues #8 and #208 I've created a regex that will allow user to use any character as column name.
It will also keep functionality of allowing user to enter 'column as alias' as column name.
I've made an assumption that no one in right mind will have spaces on beginning or end of column name so they are ignored by regex.