### PR TITLE
fix Adapter\Driver\Pdo\Result::valid() problem

### DIFF
--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -195,7 +195,7 @@ class Result implements Iterator, ResultInterface
      */
     public function valid()
     {
-        return ($this->currentData !== false);
+        return isset($this->currentData) && ($this->currentData !== false);
     }
 
     /**


### PR DESCRIPTION
problem:
When result count is 0 and no query method was executed(eg:current(),next()) $this->currentData is null type.So valid() will return true.
```
while ($list->valid()) {
         $list->current();//false if $list->count()===0
         $list->next();
}
```