### PR TITLE
Fix Exception Firebird driver doesn't support lastInsertId

### DIFF
--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -411,7 +411,8 @@ class Connection extends AbstractConnection
      */
     public function getLastGeneratedValue($name = null)
     {
-        if ($name === null && $this->driverName == 'pgsql') {
+        if ($name === null
+            && ($this->driverName == 'pgsql' || $this->driverName == 'firebird')) {
             return;
         }
 


### PR DESCRIPTION
When trying to use PDO with firebase, the following exception is raised: SQLSTATE[IM001]: Driver does not support this function: driver does not support lastInsertId()

The Firebird driver doesn't support the lastInsertId function. This function is called by getLastGeneratedValue function in every insert, update and delete and throw an exception.

This fix removes the call to lastInsertId when using firebase, based on PDO’s driverName.