### PR TITLE
Adding a fix for #267.

### DIFF
--- a/src/Adapter/Platform/AbstractPlatform.php
+++ b/src/Adapter/Platform/AbstractPlatform.php
@@ -19,7 +19,7 @@ abstract class AbstractPlatform implements PlatformInterface
     /**
      * @var string
      */
-    protected $quoteIdentifierTo = '\'';
+    protected $quoteIdentifierTo = '""';
 
     /**
      * @var bool

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -17,13 +17,6 @@ use Zend\Db\Adapter\Exception;
 class Postgresql extends AbstractPlatform
 {
     /**
-     * Overrides value from AbstractPlatform to use proper escaping for Postgres
-     *
-     * @var string
-     */
-    protected $quoteIdentifierTo = '""';
-
-    /**
      * @var resource|\PDO
      */
     protected $resource = null;

--- a/src/Adapter/Platform/Sqlite.php
+++ b/src/Adapter/Platform/Sqlite.php
@@ -16,16 +16,6 @@ use Zend\Db\Adapter\Exception;
 class Sqlite extends AbstractPlatform
 {
     /**
-     * {@inheritDoc}
-     */
-    protected $quoteIdentifier = ['"','"'];
-
-    /**
-     * {@inheritDoc}
-     */
-    protected $quoteIdentifierTo = '\'';
-
-    /**
      * @var \PDO
      */
     protected $resource = null;

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -181,6 +181,8 @@ abstract class AbstractSql implements SqlInterface
                     );
                 } elseif ($type == ExpressionInterface::TYPE_IDENTIFIER) {
                     $values[$vIndex] = $platform->quoteIdentifierInFragment($value);
+                } elseif ($type == ExpressionInterface::TYPE_IDENTIFIER_ATOMIC) {
+                    $values[$vIndex] = $platform->quoteIdentifier($value);
                 } elseif ($type == ExpressionInterface::TYPE_VALUE) {
                     // if prepareType is set, it means that this particular value must be
                     // passed back to the statement in a way it can be used as a placeholder value

--- a/src/Sql/Ddl/Column/AbstractTimestampColumn.php
+++ b/src/Sql/Ddl/Column/AbstractTimestampColumn.php
@@ -27,7 +27,7 @@ abstract class AbstractTimestampColumn extends Column
         $params[] = $this->name;
         $params[] = $this->type;
 
-        $types = [self::TYPE_IDENTIFIER, self::TYPE_LITERAL];
+        $types = [self::TYPE_IDENTIFIER_ATOMIC, self::TYPE_LITERAL];
 
         if (!$this->isNullable) {
             $spec .= ' NOT NULL';

--- a/src/Sql/Ddl/Column/Column.php
+++ b/src/Sql/Ddl/Column/Column.php
@@ -168,7 +168,7 @@ class Column implements ColumnInterface
         $params[] = $this->name;
         $params[] = $this->type;
 
-        $types = [self::TYPE_IDENTIFIER, self::TYPE_LITERAL];
+        $types = [self::TYPE_IDENTIFIER_ATOMIC, self::TYPE_LITERAL];
 
         if (!$this->isNullable) {
             $spec .= ' NOT NULL';

--- a/src/Sql/Ddl/Constraint/AbstractConstraint.php
+++ b/src/Sql/Ddl/Constraint/AbstractConstraint.php
@@ -109,7 +109,7 @@ abstract class AbstractConstraint implements ConstraintInterface
         if ($this->name) {
             $newSpec .= $this->namedSpecification;
             $values[] = $this->name;
-            $newSpecTypes[] = self::TYPE_IDENTIFIER;
+            $newSpecTypes[] = self::TYPE_IDENTIFIER_ATOMIC;
         }
 
         $newSpec .= $this->specification;
@@ -117,7 +117,7 @@ abstract class AbstractConstraint implements ConstraintInterface
         if ($colCount) {
             $values = array_merge($values, $this->columns);
             $newSpecParts = array_fill(0, $colCount, '%s');
-            $newSpecTypes = array_merge($newSpecTypes, array_fill(0, $colCount, self::TYPE_IDENTIFIER));
+            $newSpecTypes = array_merge($newSpecTypes, array_fill(0, $colCount, self::TYPE_IDENTIFIER_ATOMIC));
             $newSpec .= sprintf($this->columnSpecification, implode(', ', $newSpecParts));
         }
 

--- a/src/Sql/Ddl/Index/Index.php
+++ b/src/Sql/Ddl/Index/Index.php
@@ -55,7 +55,7 @@ class Index extends AbstractIndex
         $colCount     = count($this->columns);
         $values       = [];
         $values[]     = $this->name ?: '';
-        $newSpecTypes = [self::TYPE_IDENTIFIER];
+        $newSpecTypes = [self::TYPE_IDENTIFIER_ATOMIC];
         $newSpecParts = [];
 
         for ($i = 0; $i < $colCount; $i++) {
@@ -66,7 +66,7 @@ class Index extends AbstractIndex
             }
 
             $newSpecParts[] = $specPart;
-            $newSpecTypes[] = self::TYPE_IDENTIFIER;
+            $newSpecTypes[] = self::TYPE_IDENTIFIER_ATOMIC;
         }
 
         $newSpec = str_replace('...', implode(', ', $newSpecParts), $this->specification);

--- a/src/Sql/ExpressionInterface.php
+++ b/src/Sql/ExpressionInterface.php
@@ -12,6 +12,7 @@ namespace Zend\Db\Sql;
 interface ExpressionInterface
 {
     const TYPE_IDENTIFIER = 'identifier';
+    const TYPE_IDENTIFIER_ATOMIC = 'identifier_atomic';
     const TYPE_VALUE = 'value';
     const TYPE_LITERAL = 'literal';
     const TYPE_SELECT = 'select';


### PR DESCRIPTION
In #267 I described the incorrect behaviour, when generating DDLs with characters in name that are used for escaping on different plattforms. This is an attempt to fix it.
I tested the behaviour and it corrects the script generation with the base (PostgreSQL, SQLite) and MySQL escaping behaviour.

MSSQL seems to behave like standard despite having separate escaping, so I didn't touch it. I was able to test with driver `Pdo_SqlServer`, perhaps it uses the escaping with brackets, if `Sqlsrv` driver is used, but I couldn't test it, because I don't have the corresponding extension installed. I get the RuntimeException with message `The Sqlsrv extension is required for this adapter but the extension is not loaded`. @alextech Can you test the example in #267 and add the [] brackets to every named element? If it uses the brackets for escaping and is wrong, is it fixed, if you change in `Zend\Db\Adapter\Platform\SqlSserver` $quoteIdentifierTo to
```php
    protected $quoteIdentifierTo = '[]';
```
At least from my tests SQL Management Studio escapes the opening bracket in names by adding the closing bracket to it, when I generate a CREATE TABLE script.