### PR TITLE
explicitly display mysqli error

### DIFF
--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -206,7 +206,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $this->resource = $this->mysqli->prepare($sql);
         if (!$this->resource instanceof \mysqli_stmt) {
             throw new Exception\InvalidQueryException(
-                'Statement couldn\'t be produced with sql: ' . $sql,
+                ' Error #' . $this->mysqli->errno . ': ' . $this->mysqli->error .
+                '. Statement couldn\'t be produced with sql: ' . $sql,
                 null,
                 new Exception\ErrorException($this->mysqli->error, $this->mysqli->errno)
             );


### PR DESCRIPTION
Minor change to show mysqli errno and error explicitly. Without this, mysqli errors do not get shown in some debuggers when preparing sql statements, for example [whoops](https://filp.github.io/whoops/). 

Here is an example with whoops before
![original_schema_error](https://user-images.githubusercontent.com/16896053/31135530-2fbad6f0-a85d-11e7-8c78-b03f39f2c0e3.png)

and after the change.
![schema_error_corrected](https://user-images.githubusercontent.com/16896053/31135535-32ec4958-a85d-11e7-9b11-d8351771d2b5.png)

I think some components already use this style, for example [zend-http/src/Client/Adapter/Socket.php](https://github.com/zendframework/zend-http/blob/master/src/Client/Adapter/Socket.php#L278) line 278. 