### PR TITLE
Allow invokable classes as predicate (solves #270)

### DIFF
--- a/src/Sql/Predicate/PredicateSet.php
+++ b/src/Sql/Predicate/PredicateSet.php
@@ -78,7 +78,7 @@ class PredicateSet implements PredicateInterface, Countable
             $this->addPredicate($predicates, $combination);
             return $this;
         }
-        if ($predicates instanceof \Closure) {
+        if ($predicates instanceof \Closure || is_callable($predicates)) {
             $predicates($this);
             return $this;
         }

--- a/test/Sql/DeleteTest.php
+++ b/test/Sql/DeleteTest.php
@@ -13,6 +13,7 @@ use Zend\Db\Sql\Delete;
 use Zend\Db\Sql\Predicate\IsNotNull;
 use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Sql\Where;
+use ZendTest\Db\TestAsset\WhereInvokable;
 
 class DeleteTest extends \PHPUnit_Framework_TestCase
 {
@@ -103,6 +104,25 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         $this->delete->where(function ($what) use ($where) {
             $this->assertSame($where, $what);
         });
+    }
+
+    /**
+     * @testdox unit test: test where will accept invokable classes
+     * @covers Zend\Db\Sql\Update::where
+     */
+    public function testWhereArgumentCanBeInvokable()
+    {
+        $select = new Delete;
+        $select->where(new WhereInvokable('bar'));
+
+        /** @var Where $where */
+        $where = $select->getRawState('where');
+        $predicates = $where->getPredicates();
+        $expressionData = $predicates[0][1]->getExpressionData();
+
+        $this->assertEquals(1, count($predicates));
+        $this->assertEquals('foo', $expressionData[0][1][0]);
+        $this->assertEquals('bar', $expressionData[0][1][1]);
     }
 
     /**

--- a/test/Sql/SelectTest.php
+++ b/test/Sql/SelectTest.php
@@ -19,6 +19,7 @@ use Zend\Db\Sql\Select;
 use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Sql\Where;
 use ZendTest\Db\TestAsset\TrustingSql92Platform;
+use ZendTest\Db\TestAsset\WhereInvokable;
 
 class SelectTest extends \PHPUnit_Framework_TestCase
 {
@@ -346,6 +347,25 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select->where(function ($what) use ($where) {
             $this->assertSame($where, $what);
         });
+    }
+
+    /**
+     * @testdox unit test: test where will accept invokable classes
+     * @covers Zend\Db\Sql\Select::where
+     */
+    public function testWhereArgumentCanBeInvokable()
+    {
+        $select = new Select;
+        $select->where(new WhereInvokable('bar'));
+
+        /** @var Where $where */
+        $where = $select->getRawState('where');
+        $predicates = $where->getPredicates();
+        $expressionData = $predicates[0][1]->getExpressionData();
+
+        $this->assertEquals(1, count($predicates));
+        $this->assertEquals('foo', $expressionData[0][1][0]);
+        $this->assertEquals('bar', $expressionData[0][1][1]);
     }
 
     /**

--- a/test/Sql/UpdateTest.php
+++ b/test/Sql/UpdateTest.php
@@ -15,6 +15,7 @@ use Zend\Db\Sql\Where;
 use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\TableIdentifier;
 use ZendTest\Db\TestAsset\TrustingSql92Platform;
+use ZendTest\Db\TestAsset\WhereInvokable;
 
 class UpdateTest extends \PHPUnit_Framework_TestCase
 {
@@ -166,6 +167,25 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $this->update->getRawState('emptyWhereProtection'));
         $this->assertEquals(['bar' => 'baz'], $this->update->getRawState('set'));
         $this->assertInstanceOf('Zend\Db\Sql\Where', $this->update->getRawState('where'));
+    }
+
+    /**
+     * @testdox unit test: test where will accept invokable classes
+     * @covers Zend\Db\Sql\Update::where
+     */
+    public function testWhereArgumentCanBeInvokable()
+    {
+        $select = new Update;
+        $select->where(new WhereInvokable('bar'));
+
+        /** @var Where $where */
+        $where = $select->getRawState('where');
+        $predicates = $where->getPredicates();
+        $expressionData = $predicates[0][1]->getExpressionData();
+
+        $this->assertEquals(1, count($predicates));
+        $this->assertEquals('foo', $expressionData[0][1][0]);
+        $this->assertEquals('bar', $expressionData[0][1][1]);
     }
 
     /**

--- a/test/TestAsset/WhereInvokable.php
+++ b/test/TestAsset/WhereInvokable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Sql\Predicate\Like;
+use Zend\Db\Sql\Select;
+
+class WhereInvokable
+{
+    private $value;
+
+    /**
+     * WhereInvokable constructor.
+     * @param $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __invoke($select)
+    {
+        /** @var Select $select */
+        $select->where->addPredicate(new Like('foo', $this->value));
+    }
+
+}


### PR DESCRIPTION
This PR solves #270 .
Predicates can now created from an invokable class. Like closures, the new predicates should directly added to the Select, Where or Update instance.