### PR TITLE
Implement our own error handler for db2_prepare

### DIFF
--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Db\Adapter\Driver\IbmDb2;
 
+use ErrorException;
+use Throwable;
 use Zend\Db\Adapter\Driver\StatementInterface;
 use Zend\Db\Adapter\Exception;
 use Zend\Db\Adapter\ParameterContainer;
@@ -172,7 +174,14 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             $sql = $this->sql;
         }
 
-        $this->resource = db2_prepare($this->db2, $sql);
+        try {
+            set_error_handler($this->createErrorHandler());
+            $this->resource = db2_prepare($this->db2, $sql);
+        } catch (Throwable $e) {
+            throw new Exception\RuntimeException($e->getMessage() . '. ' . db2_stmt_errormsg(), db2_stmt_error(), $e);
+        } finally {
+            restore_error_handler();
+        }
 
         if ($this->resource === false) {
             throw new Exception\RuntimeException(db2_stmt_errormsg(), db2_stmt_error());
@@ -237,5 +246,32 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
         $result = $this->driver->createResult($this->resource);
         return $result;
+    }
+
+    /**
+     * Creates and returns a callable error handler that raises exceptions.
+     *
+     * Only raises exceptions for errors that are within the error_reporting mask.
+     *
+     * @return callable
+     */
+    private function createErrorHandler() : callable
+    {
+        /**
+         * @param int $errno
+         * @param string $errstr
+         * @param string $errfile
+         * @param int $errline
+         * @return void
+         * @throws ErrorException if error is not within the error_reporting mask.
+         */
+        return function (int $errno, string $errstr, string $errfile, int $errline) : void {
+            if (! (error_reporting() & $errno)) {
+                // error_reporting does not include this error
+                return;
+            }
+
+            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+        };
     }
 }

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -177,7 +177,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         try {
             set_error_handler($this->createErrorHandler());
             $this->resource = db2_prepare($this->db2, $sql);
-        } catch (Throwable $e) {
+        } catch (ErrorException $e) {
             throw new Exception\RuntimeException($e->getMessage() . '. ' . db2_stmt_errormsg(), db2_stmt_error(), $e);
         } finally {
             restore_error_handler();

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -10,7 +10,6 @@
 namespace Zend\Db\Adapter\Driver\IbmDb2;
 
 use ErrorException;
-use Throwable;
 use Zend\Db\Adapter\Driver\StatementInterface;
 use Zend\Db\Adapter\Exception;
 use Zend\Db\Adapter\ParameterContainer;

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -255,7 +255,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      *
      * @return callable
      */
-    private function createErrorHandler() : callable
+    private function createErrorHandler()
     {
         /**
          * @param int $errno
@@ -265,7 +265,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
          * @return void
          * @throws ErrorException if error is not within the error_reporting mask.
          */
-        return function (int $errno, string $errstr, string $errfile, int $errline) : void {
+        return function ($errno, $errstr, $errfile, $errline) {
             if (! (error_reporting() & $errno)) {
                 // error_reporting does not include this error
                 return;

--- a/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Db\Adapter\Driver\IbmDb2;
 
 use Zend\Db\Adapter\Driver\IbmDb2\IbmDb2;
 use Zend\Db\Adapter\Driver\IbmDb2\Statement;
+use Zend\Db\Adapter\Exception\RuntimeException;
 
 /**
  * @group integration
@@ -82,6 +83,24 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($statement->isPrepared());
         $this->assertSame($statement, $statement->prepare("SELECT 'foo' FROM SYSIBM.SYSDUMMY1"));
         $this->assertTrue($statement->isPrepared());
+        unset($resource, $db2Resource);
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
+     */
+    public function testPrepareThrowsAnExceptionOnFailure()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $db2Resource = db2_connect(
+            $this->variables['database'],
+            $this->variables['username'],
+            $this->variables['password']
+        );
+        $statement = new Statement;
+        $statement->initialize($db2Resource);
+        $statement->prepare("SELECT");
         unset($resource, $db2Resource);
     }
 

--- a/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
@@ -100,7 +100,6 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
         $statement->initialize($db2Resource);
         $this->setExpectedException(RuntimeException::class);
         $statement->prepare("SELECT");
-        unset($resource, $db2Resource);
     }
 
     /**

--- a/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
@@ -64,7 +64,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $statement = new Statement;
         $statement->initialize($db2Resource);
-        $statement->prepare("SELECT 'foo'");
+        $statement->prepare("SELECT 'foo' FROM sysibm.sysdummy1");
         $resource = $statement->getResource();
         $this->assertEquals('DB2 Statement', get_resource_type($resource));
         unset($resource, $db2Resource);
@@ -88,11 +88,10 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
+     * @expectedException RuntimeException
      */
     public function testPrepareThrowsAnExceptionOnFailure()
     {
-        $this->expectException(RuntimeException::class);
-
         $db2Resource = db2_connect(
             $this->variables['database'],
             $this->variables['username'],

--- a/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementIntegrationTest.php
@@ -88,7 +88,6 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
-     * @expectedException RuntimeException
      */
     public function testPrepareThrowsAnExceptionOnFailure()
     {
@@ -99,6 +98,7 @@ class StatementIntegrationTest extends \PHPUnit_Framework_TestCase
         );
         $statement = new Statement;
         $statement->initialize($db2Resource);
+        $this->setExpectedException(RuntimeException::class);
         $statement->prepare("SELECT");
         unset($resource, $db2Resource);
     }

--- a/test/Adapter/Driver/IbmDb2/StatementTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementTest.php
@@ -29,6 +29,9 @@ class StatementTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        // store current error_reporting value as we may change it
+        // in a test
+        $this->currentErrorReporting = error_reporting();
         $this->statement = new Statement;
     }
 
@@ -38,6 +41,8 @@ class StatementTest extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+        // ensure error_reporting is set back to correct value
+        error_reporting($this->currentErrorReporting);
     }
 
     /**
@@ -157,7 +162,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
      */
     public function testPrepareThrowsRuntimeExceptionOnInvalidSqlWithErrorReportingDisabled()
     {
-        $currentErrorReporting = error_reporting(0);
+        error_reporting(0);
         $sql = "INVALID SQL";
         $this->statement->setSql($sql);
 
@@ -166,8 +171,6 @@ class StatementTest extends \PHPUnit_Framework_TestCase
             'Error message'
         );
         $this->statement->prepare();
-
-        error_reporting($currentErrorReporting);
     }
 
     /**

--- a/test/Adapter/Driver/IbmDb2/StatementTest.php
+++ b/test/Adapter/Driver/IbmDb2/StatementTest.php
@@ -12,6 +12,9 @@ namespace ZendTest\Db\Adapter\Driver\IbmDb2;
 use Zend\Db\Adapter\Driver\IbmDb2\Statement;
 use Zend\Db\Adapter\Driver\IbmDb2\IbmDb2;
 use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Exception\RuntimeException;
+
+include __DIR__ . '/TestAsset/Db2Functions.php';
 
 class StatementTest extends \PHPUnit_Framework_TestCase
 {
@@ -102,26 +105,69 @@ class StatementTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
-     * @todo   Implement testPrepare().
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::isPrepared
      */
     public function testPrepare()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-          'This test has not been implemented yet.'
-        );
+        $sql = "SELECT 'foo' FROM SYSIBM.SYSDUMMY1";
+        $this->statement->prepare($sql);
+        $this->assertTrue($this->statement->isPrepared());
     }
 
     /**
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::isPrepared
-     * @todo   Implement testIsPrepared().
      */
-    public function testIsPrepared()
+    public function testPreparingTwiceErrors()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-          'This test has not been implemented yet.'
+        $sql = "SELECT 'foo' FROM SYSIBM.SYSDUMMY1";
+        $this->statement->prepare($sql);
+        $this->assertTrue($this->statement->isPrepared());
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'This statement has been prepared already'
         );
+        $this->statement->prepare($sql);
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::setSql
+     */
+    public function testPrepareThrowsRuntimeExceptionOnInvalidSql()
+    {
+        $sql = "INVALID SQL";
+        $this->statement->setSql($sql);
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'SQL is invalid. Error message'
+        );
+        $this->statement->prepare();
+    }
+
+    /**
+     * If error_reporting() is turned off, then the error handler will not
+     * be called, but a RuntimeException will still be generated as the
+     * resource is false
+     *
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::prepare
+     * @covers Zend\Db\Adapter\Driver\IbmDb2\Statement::setSql
+     */
+    public function testPrepareThrowsRuntimeExceptionOnInvalidSqlWithErrorReportingDisabled()
+    {
+        $currentErrorReporting = error_reporting(0);
+        $sql = "INVALID SQL";
+        $this->statement->setSql($sql);
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'Error message'
+        );
+        $this->statement->prepare();
+
+        error_reporting($currentErrorReporting);
     }
 
     /**

--- a/test/Adapter/Driver/IbmDb2/TestAsset/Db2Functions.php
+++ b/test/Adapter/Driver/IbmDb2/TestAsset/Db2Functions.php
@@ -1,0 +1,57 @@
+<?php
+namespace Zend\Db\Adapter\Driver\IbmDb2;
+
+/**
+ * Mock db2_prepare by placing in same namespace as Statement
+ *
+ * Return false if $sql is "invalid sql", otherwise return true
+ *
+ * @param  resource $adapter
+ * @param  string $sql
+ * @param  array $options
+ * @return resource|false
+ */
+function db2_prepare($connection, $sql, $options = [])
+{
+    if ($sql == 'INVALID SQL') {
+        // db2_prepare issues a warning with invalid SQL
+        trigger_error("SQL is invalid", E_USER_WARNING);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Mock db2_stmt_errormsg
+ *
+ * If you pass a string to $stmt, it will be returned to you
+ *
+ * @param mixed $stmt
+ * @return string
+ */
+function db2_stmt_errormsg($stmt = null)
+{
+    if (is_string($stmt)) {
+        return $stmt;
+    }
+
+    return 'Error message';
+}
+
+/**
+ * Mock db2_stmt_error
+ *
+ * If you pass a string to $stmt, it will be returned to you
+ *
+ * @param mixed $stmt
+ * @return string
+ */
+function db2_stmt_error($stmt = null)
+{
+    if (is_string($stmt)) {
+        return $stmt;
+    }
+
+    return '1';
+}


### PR DESCRIPTION
db2_prepare() may issue a [warning][1] in addition to returning false.
If you have an error handler set (e.g. in the Expressive pipeline) then
the message created is "db2_prepare(): Statement Prepare Failed" which
is not helpful.

Therefore, we create our own error handler and trap this ourselves so
that we can throw an ErrorException with more information from
db2_stmt_errormsg().

I've left the previous handling as I don't know PHP extension code well enough to be 100% sure that db2_prepare() always generates a warning when it returns false.

[1]: https://github.com/php/pecl-database-ibm_db2/blob/df913feb4dff56366ac4656b0bb6b39200794bde/ibm_db2.c#L4400