### PR TITLE
Add support for LIMIT OFFSET for db2

### DIFF
--- a/src/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/src/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -27,7 +27,13 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      */
     protected $subject = null;
 
-    /**
+     /**
+     * @var bool
+     */
+    protected $supportsLimitOffset = false;
+
+
+   /**
      * @return bool
      */
     public function getIsSelectContainDistinct()
@@ -49,6 +55,22 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     public function setSubject($select)
     {
         $this->subject = $select;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getSupportsLimitOffset()
+    {
+        return $this->supportsLimitOffset;
+    }
+
+    /**
+     * @param bool $supportsLimitOffset
+     */
+    public function setSupportsLimitOffset($supportsLimitOffset)
+    {
+        $this->supportsLimitOffset = $supportsLimitOffset;
     }
 
     /**
@@ -79,6 +101,20 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     protected function processLimitOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, &$sqls, &$parameters)
     {
         if ($this->limit === null && $this->offset === null) {
+            return;
+        }
+
+        if ($this->supportsLimitOffset) {
+            // Note: db2_prepare/db2_execute fails with positional parameters, for LIMIT & OFFSET
+            $limit = (int)$this->limit;
+            $offset = (int)$this->offset;
+            if ($this->limit) {
+                if ($this->offset) {
+                    array_push($sqls, sprintf("LIMIT %s OFFSET %s", $limit, $offset));
+                } else {
+                    array_push($sqls, sprintf("LIMIT %s", $limit));
+                }
+            }
             return;
         }
 

--- a/src/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/src/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -107,12 +107,11 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($this->supportsLimitOffset) {
             // Note: db2_prepare/db2_execute fails with positional parameters, for LIMIT & OFFSET
             $limit = (int)$this->limit;
-            $offset = (int)$this->offset;
-
             if (! $limit) {
                 return;
             }
 
+            $offset = (int)$this->offset;
             if ($offset) {
                 array_push($sqls, sprintf("LIMIT %s OFFSET %s", $limit, $offset));
                 return;

--- a/src/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/src/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -106,12 +106,12 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
 
         if ($this->supportsLimitOffset) {
             // Note: db2_prepare/db2_execute fails with positional parameters, for LIMIT & OFFSET
-            $limit = (int)$this->limit;
+            $limit = (int) $this->limit;
             if (! $limit) {
                 return;
             }
 
-            $offset = (int)$this->offset;
+            $offset = (int) $this->offset;
             if ($offset) {
                 array_push($sqls, sprintf("LIMIT %s OFFSET %s", $limit, $offset));
                 return;

--- a/src/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/src/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -108,13 +108,17 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             // Note: db2_prepare/db2_execute fails with positional parameters, for LIMIT & OFFSET
             $limit = (int)$this->limit;
             $offset = (int)$this->offset;
-            if ($this->limit) {
-                if ($this->offset) {
-                    array_push($sqls, sprintf("LIMIT %s OFFSET %s", $limit, $offset));
-                } else {
-                    array_push($sqls, sprintf("LIMIT %s", $limit));
-                }
+
+            if (! $limit) {
+                return;
             }
+
+            if ($offset) {
+                array_push($sqls, sprintf("LIMIT %s OFFSET %s", $limit, $offset));
+                return;
+            }
+
+            array_push($sqls, sprintf("LIMIT %s", $limit));
             return;
         }
 


### PR DESCRIPTION
Since 2016, DB2 has supported the `LIMIT x OFFSET y` construct. This PR supports the new construct in a BC manner via a feature flag. To use with TableGateway:

```
$tableGateway = new TableGateway($table, $adapter);
$decorator = $tableGateway->getSql()->getSqlPlatform()->getDecorators()['Zend\Db\Sql\Select'];
$decorator->setSupportsLimitOffset(true);
``` 