### PR TITLE
pdo_dblib added version dsn parameter

### DIFF
--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -202,6 +202,9 @@ class Connection extends AbstractConnection
                 case 'unix_socket':
                     $unix_socket = (string) $value;
                     break;
+                case 'version':
+                    $version = (string) $value;
+                    break;
                 case 'driver_options':
                 case 'options':
                     $value = (array) $value;
@@ -249,6 +252,9 @@ class Connection extends AbstractConnection
                     }
                     if (isset($unix_socket)) {
                         $dsn[] = "unix_socket={$unix_socket}";
+                    }
+                    if (isset($version)) {
+                        $dsn[] = "version={$version}";
                     }
                     break;
             }

--- a/test/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/test/Adapter/Driver/Pdo/ConnectionTest.php
@@ -97,4 +97,26 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         ]);
         $this->connection->connect();
     }
+
+    public function testDblibArrayOfConnectionParametersCreatesCorrectDsn()
+    {
+        $this->connection->setConnectionParameters([
+            'driver'  => 'pdo_dblib',
+            'charset' => 'UTF-8',
+            'dbname'  => 'foo',
+            'port'    => '1433',
+            'version' => '7.3',
+        ]);
+        try {
+            $this->connection->connect();
+        } catch (\Exception $e) {
+        }
+        $responseString = $this->connection->getDsn();
+
+        $this->assertStringStartsWith('dblib:', $responseString);
+        $this->assertContains('charset=UTF-8', $responseString);
+        $this->assertContains('dbname=foo', $responseString);
+        $this->assertContains('port=1433', $responseString);
+        $this->assertContains('version=7.3', $responseString);
+    }
 }


### PR DESCRIPTION
Currently it is not possible to set **version** parameter when connecting to MSSQL server via [pdo_dblib](http://php.net/manual/en/ref.pdo-dblib.connection.php#112146). This PR adds this parameter.