### PR TITLE
Hotfix #285

### DIFF
--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -243,7 +243,7 @@ abstract class AbstractSql implements SqlInterface
                 foreach ($paramsForPosition as $multiParamsForPosition) {
                     if (is_array($multiParamsForPosition) || $multiParamsForPosition instanceof Countable) {
                         $ppCount = count($multiParamsForPosition);
-                    } elseif (is_string($multiParamsForPosition)) {
+                    } else {
                         $ppCount = 1;
                     }
 

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -241,7 +241,7 @@ abstract class AbstractSql implements SqlInterface
             if (isset($paramSpecs[$position]['combinedby'])) {
                 $multiParamValues = [];
                 foreach ($paramsForPosition as $multiParamsForPosition) {
-                    if (is_array($multiParamsForPosition) || $multiParamsForPosition instanceof Countable) {
+                    if (is_array($multiParamsForPosition)) {
                         $ppCount = count($multiParamsForPosition);
                     } else {
                         $ppCount = 1;


### PR DESCRIPTION
I've checked and changing to `else` is good enough solution. Even if we have there non-string type it's gonna work as before, see: 
https://wiki.php.net/rfc/counting_non_countables\

> Calling `count()` on a scalar or object that doesn't implement the Countable interface returns 1.

Removed also part of the condition to check if variable is instance of Countable. It is not possible in that place. Please note the condition was wrong and not even working because `Countable` was not imported.

Resolves #285 

/cc @ezimuel @remicollet 