### PR TITLE
Revert PR #224 due to issue like #288

### DIFF
--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -304,8 +304,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && ! is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
-            // using MD5 because of the PDO restriction [A-Za-z0-9_] for bindParam name
-            return ':' . md5($name);
+            return ':' . $name;
         }
 
         return '?';

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -304,6 +304,14 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && ! is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
+            // @see https://bugs.php.net/bug.php?id=43130
+            if (preg_match('/[^a-zA-Z0-9_]/', $name)) {
+                throw new Exception\RuntimeException(sprintf(
+                    "The PDO param %s contains characters not allowed. " .
+                    "You can use only letter, digit, and underscore (_)",
+                    $name
+                ));
+            }
             return ':' . $name;
         }
 

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -44,9 +44,13 @@ class PdoTest extends TestCase
     {
         return [
             [ 'foo', null, ':foo' ],
+            [ 'foo_bar', null, ':foo_bar' ],
+            [ '123foo', null, ':123foo' ],
             [ 1, null, '?' ],
             [ '1', null, '?' ],
             [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':foo' ],
+            [ 'foo_bar', Pdo::PARAMETERIZATION_NAMED, ':foo_bar' ],
+            [ '123foo', Pdo::PARAMETERIZATION_NAMED, ':123foo' ],
             [ 1, Pdo::PARAMETERIZATION_NAMED, ':1' ],
             [ '1', Pdo::PARAMETERIZATION_NAMED, ':1' ],
         ];
@@ -59,5 +63,24 @@ class PdoTest extends TestCase
     {
         $result = $this->pdo->formatParameterName($name, $type);
         $this->assertEquals($expected, $result);
+    }
+
+    public function getInvalidParamName()
+    {
+        return [
+            [ 'foo%' ],
+            [ 'foo-' ],
+            [ 'foo$' ],
+            [ 'foo0!' ]
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidParamName
+     * @expectedException Zend\Db\Exception\RuntimeException
+     */
+    public function testFormatParameterNameWithInvalidCharacters($name)
+    {
+        $this->pdo->formatParameterName($name);
     }
 }

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -43,16 +43,12 @@ class PdoTest extends TestCase
     public function getParamsAndType()
     {
         return [
-            [ 'foo', null, ':' . md5('foo')],
-            [ 'foo-', null, ':' . md5('foo-')],
-            [ 'foo$', null, ':' . md5('foo$')],
+            [ 'foo', null, ':foo' ],
             [ 1, null, '?' ],
-            [ '1', null, '?'],
-            [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo')],
-            [ 'foo-', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo-')],
-            [ 'foo$', Pdo::PARAMETERIZATION_NAMED, ':' . md5('foo$')],
-            [ 1, Pdo::PARAMETERIZATION_NAMED, ':' . md5('1')],
-            [ '1', Pdo::PARAMETERIZATION_NAMED, ':' . md5('1')],
+            [ '1', null, '?' ],
+            [ 'foo', Pdo::PARAMETERIZATION_NAMED, ':foo' ],
+            [ 1, Pdo::PARAMETERIZATION_NAMED, ':1' ],
+            [ '1', Pdo::PARAMETERIZATION_NAMED, ':1' ],
         ];
     }
 

--- a/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
+++ b/test/Adapter/Driver/Pdo/StatementIntegrationTest.php
@@ -55,7 +55,7 @@ class StatementIntegrationTest extends TestCase
     public function testStatementExecuteWillConvertPhpBoolToPdoBoolWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo(':' . md5('foo')),
+            $this->equalTo(':foo'),
             $this->equalTo(false),
             $this->equalTo(\PDO::PARAM_BOOL)
         );
@@ -65,7 +65,7 @@ class StatementIntegrationTest extends TestCase
     public function testStatementExecuteWillUsePdoStrByDefaultWhenBinding()
     {
         $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
-            $this->equalTo(':' . md5('foo')),
+            $this->equalTo(':foo'),
             $this->equalTo('bar'),
             $this->equalTo(\PDO::PARAM_STR)
         );

--- a/test/Adapter/Driver/Pdo/StatementTest.php
+++ b/test/Adapter/Driver/Pdo/StatementTest.php
@@ -128,28 +128,4 @@ class StatementTest extends TestCase
         $this->statement->prepare('SELECT 1');
         self::assertInstanceOf('Zend\Db\Adapter\Driver\Pdo\Result', $this->statement->execute());
     }
-
-    /**
-     * @see https://github.com/zendframework/zend-db/pull/224
-     */
-    public function testExecuteWithSpecialCharInBindParam()
-    {
-        $testSqlite = new TestAsset\SqliteMemoryPdo('CREATE TABLE test (text_ TEXT, text$ TEXT);');
-        $this->statement->setDriver(new Pdo(new Connection($testSqlite)));
-        $this->statement->initialize($testSqlite);
-
-        $this->statement->prepare(sprintf(
-            'INSERT INTO test (text_, text$) VALUES (:%s, :%s)',
-            md5('text_'),
-            md5('text$')
-        ));
-        $result = $this->statement->execute([ 'text_' => 'foo', 'text$' => 'bar']);
-        $this->assertInstanceOf(Result::class, $result);
-        $this->assertTrue($result->valid());
-
-        $result = $testSqlite->query('SELECT * FROM test');
-        $values = $result->fetch();
-        $this->assertEquals('foo', $values['text_']);
-        $this->assertEquals('bar', $values['text$']);
-    }
 }


### PR DESCRIPTION
This PR revert #224 due to issue like #288. 

**Summary:** I tried to solve #35 with #224 but I didn't cover all the use cases, for instance #288. After reading also the php-cvs [46848](http://news.php.net/php.cvs/46848) and [47302](http://news.php.net/php.cvs/47302), mentioned in PHP BUG [43130](https://bugs.php.net/bug.php?id=43130), I decided to revert #224 and mark #35 as won't fix. It's not considered a best practice to use these characters in bind param name.