### PR TITLE
Hotfix #291 - Allowed param names with `:` at the beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#292](https://github.com/zendframework/zend-db/pull/292) fixes the issue
+  with parameter names starting from colon.
 
 ## 2.9.1 - 2017-12-07
 

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -304,6 +304,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     public function formatParameterName($name, $type = null)
     {
         if ($type === null && ! is_numeric($name) || $type == self::PARAMETERIZATION_NAMED) {
+            $name = ltrim($name, ':');
             // @see https://bugs.php.net/bug.php?id=43130
             if (preg_match('/[^a-zA-Z0-9_]/', $name)) {
                 throw new Exception\RuntimeException(sprintf(

--- a/test/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/Adapter/Driver/Pdo/PdoTest.php
@@ -53,6 +53,7 @@ class PdoTest extends TestCase
             [ '123foo', Pdo::PARAMETERIZATION_NAMED, ':123foo' ],
             [ 1, Pdo::PARAMETERIZATION_NAMED, ':1' ],
             [ '1', Pdo::PARAMETERIZATION_NAMED, ':1' ],
+            [ ':foo', null, ':foo' ],
         ];
     }
 


### PR DESCRIPTION
PHP supports binding params with `:` and without. As we add it always
we should strip it out first before checking the name with regular
expression, and add it at the end.

Resolves #291 

@TakeoO @GreedyBytes can you please this solution with your code? Thanks

/ping @ezimuel 


- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to quality assurance?