### PR TITLE
Parameter $on at Select::join() allow Zend\Db\Sql\Predicate\Expression

### DIFF
--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -110,7 +110,7 @@ class Join implements Iterator, Countable
     /**
      * @param string|array|TableIdentifier $name A table name on which to join, or a single
      *     element associative array, of the form alias => table, or TableIdentifier instance
-     * @param string $on A string specification describing the fields to join on.
+     * @param string|Predicate\Expression $on A specification describing the fields to join on.
      * @param string|string[]|int|int[] $columns A single column name, an array
      *     of column names, or (a) specification(s) such as SQL_STAR representing
      *     the columns to join.

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -263,7 +263,7 @@ class Select extends AbstractPreparableSql
      * Create join clause
      *
      * @param  string|array|TableIdentifier $name
-     * @param  string $on
+     * @param  string|Predicate\Expression $on
      * @param  string|array $columns
      * @param  string $type one of the JOIN_* constants
      * @return self Provides a fluent interface


### PR DESCRIPTION
added `Predicate\Expression` to its `@params`

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?

- [x] Is this related to documentation?

This is to give user information that the `$on` parameter can be a `Zend\Db\Sql\Predicate\Expression`