### PR TITLE
Fix #295: handle empty array as datasource at AbstractResultSet::initialize() at php 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#303](https://github.com/zendframework/zend-db/pull/303) fix error when datasource passed to `AbstractResultSet::initialize()` is empty array at php 7.2 environment.
 
 ## 2.9.2 - 2017-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#303](https://github.com/zendframework/zend-db/pull/303) fix error when datasource passed to `AbstractResultSet::initialize()` is empty array at php 7.2 environment.
+- [#295](https://github.com/zendframework/zend-db/pull/295) fix error when datasource passed to `AbstractResultSet::initialize()` is empty array at php 7.2 environment.
 
 ## 2.9.2 - 2017-12-11
 

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -77,7 +77,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             // its safe to get numbers from an array
             $first = current($dataSource);
             reset($dataSource);
-            $this->fieldCount = count($first);
+            $this->fieldCount = $first === false ? 0 : count($first);
             $this->dataSource = new ArrayIterator($dataSource);
             $this->buffer = -1; // array's are a natural buffer
         } elseif ($dataSource instanceof IteratorAggregate) {

--- a/test/unit/ResultSet/AbstractResultSetTest.php
+++ b/test/unit/ResultSet/AbstractResultSetTest.php
@@ -59,6 +59,15 @@ class AbstractResultSetTest extends TestCase
     }
 
     /**
+     * @covers \Zend\Db\ResultSet\AbstractResultSet::initialize
+     */
+    public function testInitializeWithEmptyArray()
+    {
+        $resultSet = $this->getMockForAbstractClass('Zend\Db\ResultSet\AbstractResultSet');
+        self::assertSame($resultSet, $resultSet->initialize([]));
+    }
+
+    /**
      * @covers \Zend\Db\ResultSet\AbstractResultSet::buffer
      */
     public function testBuffer()


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
            is `count()` on datasource whenever datasource is empty array 
  - [x] Detail the original, incorrect behavior.
            when datasource is empty array, it got error: "count(): Parameter must be an array or an object that implements Countable"
  - [x] Detail the new, expected behavior.
            check the `current()` method, when it return `false`, set the count itself as 0.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

Fix #295