### PR TITLE
Reconnect on lost DB connection

### DIFF
--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -191,6 +191,8 @@ class Connection extends AbstractConnection
             $this->resource->close();
         }
         $this->resource = null;
+
+        return $this;
     }
 
     /**

--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -202,6 +202,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         }
 
         $sql = ($sql) ?: $this->sql;
+        $this->driver->checkConnection($this);
 
         $this->resource = $this->mysqli->prepare($sql);
         if (! $this->resource instanceof \mysqli_stmt) {


### PR DESCRIPTION
This functionality allow to enable & configure reconnect functionality using 'options' parameter in adapter.

When you are creating adapter for MySQL:

$adapter = new Adapter([
    'driver' => 'Mysqli',
    'database' => '',
    'username' => '',
    'password' => '',
    'options' => [
        'reconnect_tries' => 3
    ]
]);

You can specify reconnect_tries and if during your work connect will be lost adapter will try automatically reconnect to server.

Fix to #302 
