### PR TITLE
use direct "hydrator" property call instead of "getHydrator()" at HydratingResultSet:: toArray()

### DIFF
--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -119,7 +119,7 @@ class HydratingResultSet extends AbstractResultSet
     {
         $return = [];
         foreach ($this as $row) {
-            $return[] = $this->getHydrator()->extract($row);
+            $return[] = $this->hydrator->extract($row);
         }
         return $return;
     }


### PR DESCRIPTION
as call inside a class. 