### PR TITLE
Fixes coveralls command not found at travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,6 @@
         "test": "phpunit --colors=always --testsuite \"unit test\"",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "test-integration" : "phpunit --colors=always --testsuite \"integration test\"",
-        "upload-coverage": "coveralls -v"
+        "upload-coverage": "vendor/bin/php-coveralls -v"
     }
 }


### PR DESCRIPTION
- [x] Is this related to quality assurance?

Previously, it got `coveralls` command not found at travis: 

![screen shot 2018-03-28 at 1 56 48 am](https://user-images.githubusercontent.com/459648/37988538-59641dc4-322b-11e8-96fa-51780dbc1c24.png)

Updated to run by `vendor/bin/php-coveralls`, I guess another repository need this too.


