### PR TITLE
Change Return Type in selectWith() method

### DIFF
--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -198,8 +198,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
     /**
      * @param Select $select
-     * @return ResultSetInterface
-     * @throws \RuntimeException
+     * @return ResultSet
      */
     public function selectWith(Select $select)
     {

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -177,7 +177,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
      * Select
      *
      * @param Where|\Closure|string|array $where
-     * @return ResultSet
+     * @return AbstractResultSet
      */
     public function select($where = null)
     {
@@ -198,7 +198,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
     /**
      * @param Select $select
-     * @return ResultSet
+     * @return AbstractResultSet
      */
     public function selectWith(Select $select)
     {
@@ -210,7 +210,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
     /**
      * @param Select $select
-     * @return ResultSet
+     * @return AbstractResultSet
      * @throws Exception\RuntimeException
      */
     protected function executeSelect(Select $select)

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -57,7 +57,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected $featureSet = null;
 
     /**
-     * @var ResultSetInterface
+     * @var ResultSetInterface|AbstractResultSet
      */
     protected $resultSetPrototype = null;
 

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\TableGateway;
 
 use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\ResultSet\AbstractResultSet;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\ResultSet\ResultSetInterface;
 use Zend\Db\Sql\Delete;


### PR DESCRIPTION
Change Return Type of selectWith() method

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
> `phpstan` raises an error saying that `ResulSetInterface` has no method `current()`.
  - [x] Detail the original, incorrect behavior.
> The `selectWith()` method has defined the `@returnType` as `ResultSetInterface`.
> The method calls the method `executeSelect()`, which returns `ResultSet`.
> The return types should be the same.
> removes also the `@throws` flag as it doesn't throw an exception itself, but just the called methods.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
