### PR TITLE
Test AbstractResultSet::current() to return null on empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#313](https://github.com/zendframework/zend-db/pull/313) Fix AbstractResultSet::current() to return null on empty array.
 
 ## 2.9.3 - 2018-04-09
 

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -208,7 +208,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         if (is_array($this->buffer)) {
             $this->buffer[$this->position] = $data;
         }
-        return is_array($data) ? $data : null;
+        return is_array($data) && ! empty($data) ? $data : null;
     }
 
     /**

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -208,7 +208,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         if (is_array($this->buffer)) {
             $this->buffer[$this->position] = $data;
         }
-        return is_array($data) && ! empty($data) ? $data : null;
+        return is_array($data) ? $data : null;
     }
 
     /**

--- a/test/unit/ResultSet/AbstractResultSetTest.php
+++ b/test/unit/ResultSet/AbstractResultSetTest.php
@@ -172,6 +172,16 @@ class AbstractResultSetTest extends TestCase
     }
 
     /**
+     * @covers \Zend\Db\ResultSet\AbstractResultSet::current
+     */
+    public function testCurrentWithEmptyArrayDataInitialized()
+    {
+        $resultSet = $this->getMockForAbstractClass('Zend\Db\ResultSet\AbstractResultSet');
+        $resultSet->initialize([]);
+        $this->assertNull($resultSet->current());
+    }
+
+    /**
      * @covers \Zend\Db\ResultSet\AbstractResultSet::valid
      */
     public function testValid()


### PR DESCRIPTION
This is based on @rzjack comment at https://github.com/zendframework/zend-db/pull/303#issuecomment-383976062

Provide a narrative description of what you are trying to accomplish:

  - [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
           initialize `AbstractResultSet` with empty array.
  - [x] Detail the original, incorrect behavior.
           The `AbstractResultset::current()` return `[]`.
  - [x] Detail the new, expected behavior.
           The `AbstractResultset::current()` return null. 
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.