### PR TITLE
Add mysqli connection flags to mysqli_real_connect 

### DIFF
--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -148,6 +148,9 @@ class Connection extends AbstractConnection
             }
         }
 
+        if (isset($p['driver_options']['flags'])) {
+            $flags |= $p['driver_options']['flags'];
+        }
 
         try {
             $this->resource->real_connect($hostname, $username, $password, $database, $port, $socket, $flags);


### PR DESCRIPTION
The Mysqli driver doesn't allow setting of flags passed into mysqli_real_connect.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.

In some instances (like MySQL and PHP on Azure) MYSQLI_SSL_CLIENT needs to be set.

    'params' => [
        'host' => 'xxxx.mysql.database.azure.com',
        'port' => 3306,
        'user' => 'xxxx@xxxxx',
        'password' => 'xxxxx',
        'dbname' => 'xxxx',
        'charset' => 'utf8',
        'use_ssl' => true,
        'ssl_ca' => 'xxxxx/certs/BaltimoreCyberTrustRoot.crt.pem',
        'driver_options' => [ ]
    ]

  - [x] Detail the original, incorrect behavior.

This calls ``$this->resource->ssl_set($clientKey, $clientCert, $caCert, $caPath, $cipher);`` to configure the SSL options, but no flag is set on mysqli_real_connect. Connection to Azure subsequently fails with 'SSL connection is required' 

  - [x] Detail the new, expected behavior.

Driver should allow connecting as illustrated in azure documentation at https://docs.microsoft.com/en-us/azure/mysql/howto-configure-ssl .

Added 'flags' config key to driver_options to support the setting of flags into mysqli_real_connect. This lets users supply MYSQLI_CLIENT_SSL and other connection flags as indicated on http://www.php.net/manual/en/mysqli.real-connect.php

    'params' => [
        'host' => 'xxxx.mysql.database.azure.com',
        'port' => 3306,
        'user' => 'xxxx@xxxxx',
        'password' => 'xxxxx',
        'dbname' => 'xxxx',
        'charset' => 'utf8',
        'use_ssl' => true,
        'ssl_ca' => 'xxxxx/certs/BaltimoreCyberTrustRoot.crt.pem',
        'driver_options' => [ 
            'flags' => MYSQLI_CLIENT_SSL 
        ]
    ]

