### PR TITLE
remove unneeded strtolower() call as previously already called

### DIFF
--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -171,7 +171,6 @@ class Connection extends AbstractConnection
                     if (strpos($value, 'pdo') === 0) {
                         $pdoDriver = str_replace(['-', '_', ' '], '', $value);
                         $pdoDriver = substr($pdoDriver, 3) ?: '';
-                        $pdoDriver = strtolower($pdoDriver);
                     }
                     break;
                 case 'pdodriver':


### PR DESCRIPTION
- [x] Is this related to quality assurance?

In previous line, there is already `$value = strtolower((string) $value);`