### PR TITLE
Fixes Issue #318 - SelectDecorator - subselect limit parameter not prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#329](https://github.com/zendframework/zend-db/pull/329) fix Exception
+ thrown when calling prepareStatementForSqlObject on a Select with a
+ sub-Select that has limit and/or offset set
 
 ## 2.9.3 - 2018-04-09
 

--- a/src/Sql/Platform/Mysql/SelectDecorator.php
+++ b/src/Sql/Platform/Mysql/SelectDecorator.php
@@ -52,7 +52,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($parameterContainer) {
             $paramPrefix = $this->processInfo['paramPrefix'];
             $parameterContainer->offsetSet($paramPrefix . 'limit', $this->limit, ParameterContainer::TYPE_INTEGER);
-            return [$driver->formatParameterName('limit')];
+            return [$driver->formatParameterName($paramPrefix . 'limit')];
         }
 
         return [$this->limit];
@@ -69,7 +69,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($parameterContainer) {
             $paramPrefix = $this->processInfo['paramPrefix'];
             $parameterContainer->offsetSet($paramPrefix . 'offset', $this->offset, ParameterContainer::TYPE_INTEGER);
-            return [$driver->formatParameterName('offset')];
+            return [$driver->formatParameterName($paramPrefix . 'offset')];
         }
 
         return [$this->offset];

--- a/test/unit/Sql/Platform/Mysql/SelectDecoratorTest.php
+++ b/test/unit/Sql/Platform/Mysql/SelectDecoratorTest.php
@@ -10,9 +10,12 @@
 namespace ZendTest\Db\Sql\Platform\Mysql;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Db\Adapter\Driver\Mysqli\Connection;
+use ZendTest\Db\TestAsset\TrustingMysqlPlatform;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\Mysql as MysqlPlatform;
 use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\Platform\Mysql\SelectDecorator;
 use Zend\Db\Sql\Select;
 
@@ -57,6 +60,40 @@ class SelectDecoratorTest extends TestCase
     /**
      * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare
      *                            a proper limit/offset sql statement
+     * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::prepareStatement
+     * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::processLimit
+     * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::processOffset
+     * @dataProvider dataProvider
+     */
+    public function testPrepareStatementForSqlObject(
+        Select $select,
+        $ignore,
+        $expectedParams,
+        $alsoIgnore,
+        $expectedPdoSql
+    ) {
+        // mock the adapter, driver, and parts
+        $newStatement = new \Zend\Db\Adapter\Driver\Mysqli\Statement();
+        $driver = new \Zend\Db\Adapter\Driver\Pdo\Pdo(new \Zend\Db\Adapter\Driver\Pdo\Connection());
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+                            ->setConstructorArgs([$driver, new TrustingMysqlPlatform()])
+                            ->getMock();
+        $trustingPlatform = new TrustingMysqlPlatform();
+        $mockAdapter->expects($this->any())->method('getPlatform')->will($this->returnValue($trustingPlatform));
+        $mockAdapter->expects($this->any())->method('getDriver')->will($this->returnValue($driver));
+        // setup mock adapter
+        $this->mockAdapter = $mockAdapter;
+
+        $this->sql = new Sql($this->mockAdapter, 'foo');
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $statement = $this->sql->prepareStatementForSqlObject($select, $newStatement);
+        self::assertEquals($expectedPdoSql, $statement->getSql());
+    }
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare
+     *                            a proper limit/offset sql statement
      * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::getSqlString
      * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::processLimit
      * @covers \Zend\Db\Sql\Platform\Mysql\SelectDecorator::processOffset
@@ -71,7 +108,7 @@ class SelectDecoratorTest extends TestCase
 
         $selectDecorator = new SelectDecorator;
         $selectDecorator->setSubject($select);
-        self::assertEquals($expectedSql, $selectDecorator->getSqlString(new MysqlPlatform));
+        self::assertEquals($expectedSql, $selectDecorator->getSqlString(new TrustingMysqlPlatform));
     }
 
     public function dataProvider()
@@ -79,6 +116,7 @@ class SelectDecoratorTest extends TestCase
         $select0 = new Select;
         $select0->from('foo')->limit(5)->offset(10);
         $expectedPrepareSql0 = 'SELECT `foo`.* FROM `foo` LIMIT ? OFFSET ?';
+        $expectedPrepareObjectSql0 = 'SELECT `foo`.* FROM `foo` LIMIT :limit OFFSET :offset';
         $expectedParams0 = ['offset' => 10, 'limit' => 5];
         $expectedSql0 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10';
 
@@ -86,6 +124,7 @@ class SelectDecoratorTest extends TestCase
         $select1 = new Select;
         $select1->from('foo')->offset(10);
         $expectedPrepareSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET ?';
+        $expectedPrepareObjectSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET :offset';
         $expectedParams1 = ['offset' => 10];
         $expectedSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10';
 
@@ -93,6 +132,7 @@ class SelectDecoratorTest extends TestCase
         $select2 = new Select;
         $select2->from('foo')->limit('5')->offset('10000000000000000000');
         $expectedPrepareSql2 = 'SELECT `foo`.* FROM `foo` LIMIT ? OFFSET ?';
+        $expectedPrepareObjectSql2 = 'SELECT `foo`.* FROM `foo` LIMIT :limit OFFSET :offset';
         $expectedParams2 = ['offset' => '10000000000000000000', 'limit' => '5'];
         $expectedSql2 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10000000000000000000';
 
@@ -113,6 +153,9 @@ class SelectDecoratorTest extends TestCase
         $expectedPrepareSql3 =
             "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` LIMIT ? OFFSET ?) AS `res`"
             . " FROM `foo` LIMIT ? OFFSET ?";
+        $expectedPrepareObjectSql3 =
+        "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` LIMIT :subselect1limit OFFSET :subselect1offset) AS `res`"
+        . " FROM `foo` LIMIT :limit OFFSET :offset";
         $expectedParams3 = [
             'subselect1limit' => 100,
             'subselect1offset' => 500,
@@ -148,6 +191,10 @@ class SelectDecoratorTest extends TestCase
             "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` LIMIT ? OFFSET ?) AS `res`,"
             . " (SELECT count(foo2.id) AS `cnt` FROM `foo2` LIMIT ? OFFSET ?) AS `res0`"
             . " FROM `foo` LIMIT ? OFFSET ?";
+        $expectedPrepareObjectSql4 =
+            "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` LIMIT :subselect1limit OFFSET :subselect1offset)"
+            . " AS `res`, (SELECT count(foo2.id) AS `cnt` FROM `foo2` LIMIT :subselect2limit OFFSET :subselect2offset)"
+            . " AS `res0` FROM `foo` LIMIT :limit OFFSET :offset";
         $expectedParams4 = [
             'subselect1limit' => 100,
             'subselect1offset' => 500,
@@ -160,12 +207,43 @@ class SelectDecoratorTest extends TestCase
             . " (SELECT count(foo2.id) AS `cnt` FROM `foo2` LIMIT 50 OFFSET 101) AS `res0`"
             . " FROM `foo` LIMIT 10 OFFSET 5";
 
+        // nested limit in field param, no limit in containing select
+        $nestedSelect0 = new Select;
+        $nestedSelect0->from('foo1')
+            ->columns([
+                'cnt' => new Expression('count(foo1.id)')
+            ]);
+        $nestedSelect0->where->equalTo('foo2', 'ab');
+        $nestedSelect0->limit(1);
+
+        $select5 = new Select;
+        $select5->from('foo')
+            ->columns([
+                'res'  => $nestedSelect0,
+            ]);
+
+        $expectedPrepareSql5 =
+            "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` WHERE `foo2` = ? LIMIT ?) AS `res`"
+            . " FROM `foo`";
+        $expectedPrepareObjectSql5 =
+            "SELECT (SELECT count(foo1.id) AS `cnt` FROM `foo1` WHERE `foo2` = :subselect1where1 LIMIT"
+            . " :subselect1limit) AS `res` FROM `foo`";
+        $expectedParams5 = [
+            'subselect1limit' => 1,
+            'subselect1where1' => 'ab'
+        ];
+        $expectedSql5 = "SELECT (SELECT count(foo1.id) AS `cnt`"
+            . " FROM `foo1` WHERE `foo2` = 'ab' LIMIT 1) AS `res`"
+            . " FROM `foo`";
+
+
         return [
-            [$select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0],
-            [$select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1],
-            [$select2, $expectedPrepareSql2, $expectedParams2, $expectedSql2],
-            [$select3, $expectedPrepareSql3, $expectedParams3, $expectedSql3],
-            [$select4, $expectedPrepareSql4, $expectedParams4, $expectedSql4],
+            [$select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0, $expectedPrepareObjectSql0],
+            [$select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1, $expectedPrepareObjectSql1],
+            [$select2, $expectedPrepareSql2, $expectedParams2, $expectedSql2, $expectedPrepareObjectSql2],
+            [$select3, $expectedPrepareSql3, $expectedParams3, $expectedSql3, $expectedPrepareObjectSql3],
+            [$select4, $expectedPrepareSql4, $expectedParams4, $expectedSql4, $expectedPrepareObjectSql4],
+            [$select5, $expectedPrepareSql5, $expectedParams5, $expectedSql5, $expectedPrepareObjectSql5],
         ];
     }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
         Call `prepareStatementForSqlObject` on a `Select` with a sub-`Select` that has `limit` and/or `offset` set
  - [X] Detail the original, incorrect behavior.
         A PDO Exception is thrown: `PDOException: SQLSTATE[HY093]: Invalid parameter number: parameter was not defined`
  - [X] Detail the new, expected behavior.
        The statement is properly generated.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [X] Add a regression test that demonstrates the bug, and proves the fix.
  - [X] Add a `CHANGELOG.md` entry for the fix.
