### PR TITLE
Updated disconnect for persistent connections

### DIFF
--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -146,10 +146,14 @@ class Connection extends AbstractConnection
     /**
      * {@inheritDoc}
      */
-    public function disconnect()
+    public function disconnect($isPersistent = false)
     {
         if ($this->resource) {
-            db2_close($this->resource);
+            if ($isPersistent = false) {
+                db2_close($this->resource);
+            } else {
+                db2_pclose($this->resource);
+            }
             $this->resource = null;
         }
 


### PR DESCRIPTION
The db2_pconnect allows persistent connections to be made in the connect function, but the db2_close function in the disconnect function does not close those connections.  This change allows a boolean to be passed to the disconnect function with a value of true that will allow a persistent connection to be closed.

