### PR TITLE
Added IbmDb2 db2_pclose to disconnect

### DIFF
--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -149,7 +149,28 @@ class Connection extends AbstractConnection
     public function disconnect()
     {
         if ($this->resource) {
-            db2_close($this->resource);
+            
+            // localize
+            $p = $this->connectionParameters;
+
+            // given a list of key names, test for existence in $p
+            $findParameterValue = function (array $names) use ($p) {
+                foreach ($names as $name) {
+                    if (isset($p[$name])) {
+                        return $p[$name];
+                    }
+                }
+    
+                return;
+            };
+            $isPersistent = $findParameterValue(['persistent', 'PERSISTENT', 'Persistent']);
+            
+            if ((bool) $isPersistent) {
+                db2_pclose($this->resource);
+            } else {
+                db2_close($this->resource);    
+            }
+                        
             $this->resource = null;
         }
 


### PR DESCRIPTION
Updated the disconnect method to choose db2_pclose or db2_close based on the resource's connectionParameter for persistence.

The public function connect() creates either persistent or non persistent db2 connections based on a connection parameter.

This update uses the same logic in the public function disconnect() to close the connection.  Previously persistent connections would not have been closed with the db2_close() call, because they need the db2_pclose() call.