### PR TITLE
WIP: Fix 330, return NULL if current() is not countable

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -194,11 +194,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      */
     public function current()
     {
-        if (-1 === $this->buffer) {
-            // datasource was an array when the resultset was initialized
-            return $this->dataSource->current();
-        }
-
         if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
         } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
@@ -208,7 +203,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         if (is_array($this->buffer)) {
             $this->buffer[$this->position] = $data;
         }
-        return is_array($data) ? $data : null;
+        return (is_array($data) || $data instanceof Countable) ? $data : null;
     }
 
     /**


### PR DESCRIPTION
This PR fixes #330 returning NULL if current() result is not countable. It removes and changes part of the `Zend\Db\ResultSet\AbstractResultSet::current()` implementation modified with https://github.com/zendframework/zend-db/commit/8276cf6cfe45dce834979f0e714eea81065a7493.