### PR TITLE
Disconnect persistent IbmDb2 connection

### DIFF
--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -156,6 +156,21 @@ class Connection extends AbstractConnection
         return $this;
     }
 
+     /**
+     * Disconnect a persistent resource
+     *
+     * @return ConnectionInterface
+     */
+    public function disconnectPersistent()
+    {
+        if ($this->resource) {
+            db2_pclose($this->resource);
+            $this->resource = null;
+        }
+
+        return $this;
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -170,7 +170,7 @@ class Connection extends AbstractConnection
 
         return $this;
     }
-    
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Persistent database connections created with db2_pconnect don't close with the current disconnect method.  This change adds a callable method for closing persistent database connections by using db2_pclose().