### PR TITLE
Add insert ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#157](https://github.com/zendframework/zend-db/pull/157) added support of
   `Zend\Db\Sql\TableIdentifier` in DDL
 
+- [#336](https://github.com/zendframework/zend-db/pull/336) added `InsertIgnore` class for "INSERT IGNORE" usage (usable in `MySQL` plaftorm)
+
 ### Changed
 
 - Nothing.

--- a/src/Sql/InsertIgnore.php
+++ b/src/Sql/InsertIgnore.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql;
+
+class InsertIgnore extends Insert
+{
+    /**
+     * @var array Specification array
+     */
+    protected $specifications = [
+        self::SPECIFICATION_INSERT => 'INSERT IGNORE INTO %1$s (%2$s) VALUES (%3$s)',
+        self::SPECIFICATION_SELECT => 'INSERT IGNORE INTO %1$s %2$s %3$s',
+    ];
+}

--- a/test/unit/Sql/InsertIgnoreTest.php
+++ b/test/unit/Sql/InsertIgnoreTest.php
@@ -34,7 +34,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::into
+     * @covers \Zend\Db\Sql\InsertIgnore::into
      */
     public function testInto()
     {
@@ -47,7 +47,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::columns
+     * @covers \Zend\Db\Sql\InsertIgnore::columns
      */
     public function testColumns()
     {
@@ -57,7 +57,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::values
+     * @covers \Zend\Db\Sql\InsertIgnore::values
      */
     public function testValues()
     {
@@ -77,7 +77,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::values
+     * @covers \Zend\Db\Sql\InsertIgnore::values
      */
     public function testValuesThrowsExceptionWhenNotArrayOrSelect()
     {
@@ -87,7 +87,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::values
+     * @covers \Zend\Db\Sql\InsertIgnore::values
      */
     public function testValuesThrowsExceptionWhenSelectMergeOverArray()
     {
@@ -99,7 +99,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::values
+     * @covers \Zend\Db\Sql\InsertIgnore::values
      */
     public function testValuesThrowsExceptionWhenArrayMergeOverSelect()
     {
@@ -114,7 +114,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::values
+     * @covers \Zend\Db\Sql\InsertIgnore::values
      * @group ZF2-4926
      */
     public function testEmptyArrayValues()
@@ -124,7 +124,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::prepareStatement
+     * @covers \Zend\Db\Sql\InsertIgnore::prepareStatement
      */
     public function testPrepareStatement()
     {
@@ -172,7 +172,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::prepareStatement
+     * @covers \Zend\Db\Sql\InsertIgnore::prepareStatement
      */
     public function testPrepareStatementWithSelect()
     {
@@ -202,7 +202,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::getSqlString
+     * @covers \Zend\Db\Sql\InsertIgnore::getSqlString
      */
     public function testGetSqlString()
     {
@@ -256,7 +256,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::__set
+     * @covers \Zend\Db\Sql\InsertIgnore::__set
      */
     // @codingStandardsIgnoreStart
     public function test__set()
@@ -268,7 +268,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::__unset
+     * @covers \Zend\Db\Sql\InsertIgnore::__unset
      */
     // @codingStandardsIgnoreStart
     public function test__unset()
@@ -291,7 +291,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::__isset
+     * @covers \Zend\Db\Sql\InsertIgnore::__isset
      */
     // @codingStandardsIgnoreStart
     public function test__isset()
@@ -305,7 +305,7 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\Insert::__get
+     * @covers \Zend\Db\Sql\InsertIgnore::__get
      */
     // @codingStandardsIgnoreStart
     public function test__get()

--- a/test/unit/Sql/InsertIgnoreTest.php
+++ b/test/unit/Sql/InsertIgnoreTest.php
@@ -33,9 +33,6 @@ class InsertIgnoreTest extends TestCase
         $this->insert = new InsertIgnore;
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::into
-     */
     public function testInto()
     {
         $this->insert->into('table', 'schema');
@@ -46,9 +43,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals($tableIdentifier, $this->insert->getRawState('table'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::columns
-     */
     public function testColumns()
     {
         $columns = ['foo', 'bar'];
@@ -56,9 +50,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals($columns, $this->insert->getRawState('columns'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::values
-     */
     public function testValues()
     {
         $this->insert->values(['foo' => 'bar']);
@@ -76,9 +67,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals(['bax'], $this->insert->getRawState('values'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::values
-     */
     public function testValuesThrowsExceptionWhenNotArrayOrSelect()
     {
         $this->expectException('Zend\Db\Sql\Exception\InvalidArgumentException');
@@ -86,9 +74,6 @@ class InsertIgnoreTest extends TestCase
         $this->insert->values(5);
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::values
-     */
     public function testValuesThrowsExceptionWhenSelectMergeOverArray()
     {
         $this->insert->values(['foo' => 'bar']);
@@ -98,9 +83,6 @@ class InsertIgnoreTest extends TestCase
         $this->insert->values(new Select, InsertIgnore::VALUES_MERGE);
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::values
-     */
     public function testValuesThrowsExceptionWhenArrayMergeOverSelect()
     {
         $this->insert->values(new Select);
@@ -114,7 +96,6 @@ class InsertIgnoreTest extends TestCase
     }
 
     /**
-     * @covers \Zend\Db\Sql\InsertIgnore::values
      * @group ZF2-4926
      */
     public function testEmptyArrayValues()
@@ -123,9 +104,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals([], $this->readAttribute($this->insert, 'columns'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::prepareStatement
-     */
     public function testPrepareStatement()
     {
         $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
@@ -171,9 +149,6 @@ class InsertIgnoreTest extends TestCase
         $this->insert->prepareStatement($mockAdapter, $mockStatement);
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::prepareStatement
-     */
     public function testPrepareStatementWithSelect()
     {
         $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
@@ -201,9 +176,6 @@ class InsertIgnoreTest extends TestCase
         self::assertSame(['subselect1where1' => 5], $parameters);
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::getSqlString
-     */
     public function testGetSqlString()
     {
         $this->insert->into('foo')
@@ -255,9 +227,6 @@ class InsertIgnoreTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::__set
-     */
     // @codingStandardsIgnoreStart
     public function test__set()
     {
@@ -267,9 +236,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals(['bar'], $this->insert->getRawState('values'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::__unset
-     */
     // @codingStandardsIgnoreStart
     public function test__unset()
     {
@@ -290,9 +256,6 @@ class InsertIgnoreTest extends TestCase
         self::assertEquals([], $this->insert->getRawState('values'));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::__isset
-     */
     // @codingStandardsIgnoreStart
     public function test__isset()
     {
@@ -304,9 +267,6 @@ class InsertIgnoreTest extends TestCase
         self::assertTrue(isset($this->insert->foo));
     }
 
-    /**
-     * @covers \Zend\Db\Sql\InsertIgnore::__get
-     */
     // @codingStandardsIgnoreStart
     public function test__get()
     {
@@ -334,9 +294,6 @@ class InsertIgnoreTest extends TestCase
         );
     }
 
-    /**
-     * @coversNothing
-     */
     public function testSpecificationconstantsCouldBeOverridedByExtensionInPrepareStatement()
     {
         $replace = new Replace();
@@ -385,9 +342,6 @@ class InsertIgnoreTest extends TestCase
         $replace->prepareStatement($mockAdapter, $mockStatement);
     }
 
-    /**
-     * @coversNothing
-     */
     public function testSpecificationconstantsCouldBeOverridedByExtensionInGetSqlString()
     {
         $replace = new Replace();

--- a/test/unit/Sql/InsertIgnoreTest.php
+++ b/test/unit/Sql/InsertIgnoreTest.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\InsertIgnore;
+use Zend\Db\Sql\Select;
+use Zend\Db\Sql\TableIdentifier;
+use ZendTest\Db\TestAsset\Replace;
+use ZendTest\Db\TestAsset\TrustingSql92Platform;
+
+class InsertIgnoreTest extends TestCase
+{
+    /**
+     * @var InsertIgnore
+     */
+    protected $insert;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->insert = new InsertIgnore;
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::into
+     */
+    public function testInto()
+    {
+        $this->insert->into('table', 'schema');
+        self::assertEquals('table', $this->insert->getRawState('table'));
+
+        $tableIdentifier = new TableIdentifier('table', 'schema');
+        $this->insert->into($tableIdentifier);
+        self::assertEquals($tableIdentifier, $this->insert->getRawState('table'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::columns
+     */
+    public function testColumns()
+    {
+        $columns = ['foo', 'bar'];
+        $this->insert->columns($columns);
+        self::assertEquals($columns, $this->insert->getRawState('columns'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::values
+     */
+    public function testValues()
+    {
+        $this->insert->values(['foo' => 'bar']);
+        self::assertEquals(['foo'], $this->insert->getRawState('columns'));
+        self::assertEquals(['bar'], $this->insert->getRawState('values'));
+
+        // test will merge cols and values of previously set stuff
+        $this->insert->values(['foo' => 'bax'], InsertIgnore::VALUES_MERGE);
+        $this->insert->values(['boom' => 'bam'], InsertIgnore::VALUES_MERGE);
+        self::assertEquals(['foo', 'boom'], $this->insert->getRawState('columns'));
+        self::assertEquals(['bax', 'bam'], $this->insert->getRawState('values'));
+
+        $this->insert->values(['foo' => 'bax']);
+        self::assertEquals(['foo'], $this->insert->getRawState('columns'));
+        self::assertEquals(['bax'], $this->insert->getRawState('values'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::values
+     */
+    public function testValuesThrowsExceptionWhenNotArrayOrSelect()
+    {
+        $this->expectException('Zend\Db\Sql\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('values() expects an array of values or Zend\Db\Sql\Select instance');
+        $this->insert->values(5);
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::values
+     */
+    public function testValuesThrowsExceptionWhenSelectMergeOverArray()
+    {
+        $this->insert->values(['foo' => 'bar']);
+
+        $this->expectException('Zend\Db\Sql\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('A Zend\Db\Sql\Select instance cannot be provided with the merge flag');
+        $this->insert->values(new Select, InsertIgnore::VALUES_MERGE);
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::values
+     */
+    public function testValuesThrowsExceptionWhenArrayMergeOverSelect()
+    {
+        $this->insert->values(new Select);
+
+        $this->expectException('Zend\Db\Sql\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage(
+            'An array of values cannot be provided with the merge flag when a Zend\Db\Sql\Select instance already '
+            . 'exists as the value source'
+        );
+        $this->insert->values(['foo' => 'bar'], InsertIgnore::VALUES_MERGE);
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::values
+     * @group ZF2-4926
+     */
+    public function testEmptyArrayValues()
+    {
+        $this->insert->values([]);
+        self::assertEquals([], $this->readAttribute($this->insert, 'columns'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::prepareStatement
+     */
+    public function testPrepareStatement()
+    {
+        $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->setMethods()
+            ->setConstructorArgs([$mockDriver])
+            ->getMock();
+
+        $mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')->getMock();
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer([]);
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('INSERT IGNORE INTO "foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $this->insert->into('foo')
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()')]);
+
+        $this->insert->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $this->insert = new InsertIgnore;
+        $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->setMethods()
+            ->setConstructorArgs([$mockDriver])
+            ->getMock();
+
+        $mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')->getMock();
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer([]);
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('INSERT IGNORE INTO "sch"."foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $this->insert->into(new TableIdentifier('foo', 'sch'))
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()')]);
+
+        $this->insert->prepareStatement($mockAdapter, $mockStatement);
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::prepareStatement
+     */
+    public function testPrepareStatementWithSelect()
+    {
+        $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->setMethods()
+            ->setConstructorArgs([$mockDriver])
+            ->getMock();
+
+        $mockStatement = new \Zend\Db\Adapter\StatementContainer();
+
+        $select = new Select('bar');
+        $this->insert
+                ->into('foo')
+                ->columns(['col1'])
+                ->select($select->where(['x' => 5]))
+                ->prepareStatement($mockAdapter, $mockStatement);
+
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo" ("col1") SELECT "bar".* FROM "bar" WHERE "x" = ?',
+            $mockStatement->getSql()
+        );
+        $parameters = $mockStatement->getParameterContainer()->getNamedArray();
+        self::assertSame(['subselect1where1' => 5], $parameters);
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::getSqlString
+     */
+    public function testGetSqlString()
+    {
+        $this->insert->into('foo')
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null]);
+
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+
+        // with TableIdentifier
+        $this->insert = new InsertIgnore;
+        $this->insert->into(new TableIdentifier('foo', 'sch'))
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null]);
+
+        self::assertEquals(
+            'INSERT IGNORE INTO "sch"."foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+
+        // with Select
+        $this->insert = new InsertIgnore;
+        $select = new Select();
+        $this->insert->into('foo')->select($select->from('bar'));
+
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo"  SELECT "bar".* FROM "bar"',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+
+        // with Select and columns
+        $this->insert->columns(['col1', 'col2']);
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo" ("col1", "col2") SELECT "bar".* FROM "bar"',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+    }
+
+    public function testGetSqlStringUsingColumnsAndValuesMethods()
+    {
+        // With columns() and values()
+        $this->insert
+            ->into('foo')
+            ->columns(['col1', 'col2', 'col3'])
+            ->values(['val1', 'val2', 'val3']);
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo" ("col1", "col2", "col3") VALUES (\'val1\', \'val2\', \'val3\')',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::__set
+     */
+    // @codingStandardsIgnoreStart
+    public function test__set()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->insert->foo = 'bar';
+        self::assertEquals(['foo'], $this->insert->getRawState('columns'));
+        self::assertEquals(['bar'], $this->insert->getRawState('values'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::__unset
+     */
+    // @codingStandardsIgnoreStart
+    public function test__unset()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->insert->foo = 'bar';
+        self::assertEquals(['foo'], $this->insert->getRawState('columns'));
+        self::assertEquals(['bar'], $this->insert->getRawState('values'));
+        unset($this->insert->foo);
+        self::assertEquals([], $this->insert->getRawState('columns'));
+        self::assertEquals([], $this->insert->getRawState('values'));
+
+        $this->insert->foo = null;
+        self::assertEquals(['foo'], $this->insert->getRawState('columns'));
+        self::assertEquals([null], $this->insert->getRawState('values'));
+
+        unset($this->insert->foo);
+        self::assertEquals([], $this->insert->getRawState('columns'));
+        self::assertEquals([], $this->insert->getRawState('values'));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::__isset
+     */
+    // @codingStandardsIgnoreStart
+    public function test__isset()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->insert->foo = 'bar';
+        self::assertTrue(isset($this->insert->foo));
+
+        $this->insert->foo = null;
+        self::assertTrue(isset($this->insert->foo));
+    }
+
+    /**
+     * @covers \Zend\Db\Sql\Insert::__get
+     */
+    // @codingStandardsIgnoreStart
+    public function test__get()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->insert->foo = 'bar';
+        self::assertEquals('bar', $this->insert->foo);
+
+        $this->insert->foo = null;
+        self::assertNull($this->insert->foo);
+    }
+
+    /**
+     * @group ZF2-536
+     */
+    public function testValuesMerge()
+    {
+        $this->insert->into('foo')
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null]);
+        $this->insert->into('foo')
+            ->values(['qux' => 100], InsertIgnore::VALUES_MERGE);
+
+        self::assertEquals(
+            'INSERT IGNORE INTO "foo" ("bar", "boo", "bam", "qux") VALUES (\'baz\', NOW(), NULL, \'100\')',
+            $this->insert->getSqlString(new TrustingSql92Platform())
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInPrepareStatement()
+    {
+        $replace = new Replace();
+
+        $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->setMethods()
+            ->setConstructorArgs([$mockDriver])
+            ->getMock();
+
+        $mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')->getMock();
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer([]);
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('REPLACE INTO "foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $replace->into('foo')
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()')]);
+
+        $replace->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $replace = new Replace();
+
+        $mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->setMethods()
+            ->setConstructorArgs([$mockDriver])
+            ->getMock();
+
+        $mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')->getMock();
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer([]);
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('REPLACE INTO "sch"."foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $replace->into(new TableIdentifier('foo', 'sch'))
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()')]);
+
+        $replace->prepareStatement($mockAdapter, $mockStatement);
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInGetSqlString()
+    {
+        $replace = new Replace();
+        $replace->into('foo')
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null]);
+
+        self::assertEquals(
+            'REPLACE INTO "foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)',
+            $replace->getSqlString(new TrustingSql92Platform())
+        );
+
+        // with TableIdentifier
+        $replace = new Replace();
+        $replace->into(new TableIdentifier('foo', 'sch'))
+            ->values(['bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null]);
+
+        self::assertEquals(
+            'REPLACE INTO "sch"."foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)',
+            $replace->getSqlString(new TrustingSql92Platform())
+        );
+    }
+}


### PR DESCRIPTION
- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
            Useful to ignore duplicate entry error.
  - [x] How will users use the new feature?

```php
$insert= new InsertIgnore('tablename');
$insert->values($data);

$statement = $sql->prepareStatementForSqlObject($insert);
$statement->execute();
```
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.
