### PR TITLE
Fixes #330 current NULL for mysqli

### DIFF
--- a/src/Adapter/Driver/Mysqli/Result.php
+++ b/src/Adapter/Driver/Mysqli/Result.php
@@ -51,9 +51,9 @@ class Result implements
     protected $nextComplete = false;
 
     /**
-     * @var bool
+     * @var mixed
      */
-    protected $currentData = false;
+    protected $currentData = null;
 
     /**
      *

--- a/test/integration/Adapter/Driver/Mysqli/ConnectionTest.php
+++ b/test/integration/Adapter/Driver/Mysqli/ConnectionTest.php
@@ -12,37 +12,7 @@ use Zend\Db\Adapter\Driver\Mysqli\Connection;
 class ConnectionTest extends TestCase
 {
 
-    protected $variables = [
-        'hostname' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME',
-        'username' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_USERNAME',
-        'password' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_PASSWORD',
-        'database' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_DATABASE',
-    ];
-
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     */
-    protected function setUp()
-    {
-        if (! getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL')) {
-            $this->markTestSkipped('Mysqli integration test disabled');
-        }
-
-        if (! extension_loaded('mysqli')) {
-            $this->fail('The phpunit group integration-mysqli was enabled, but the extension is not loaded.');
-        }
-
-        foreach ($this->variables as $name => $value) {
-            if (! getenv($value)) {
-                $this->markTestSkipped(sprintf(
-                    'Missing required variable %s from phpunit.xml for this integration test',
-                    $value
-                ));
-            }
-            $this->variables[$name] = getenv($value);
-        }
-    }
+    use TraitSetup;
 
     public function testConnectionOk()
     {

--- a/test/integration/Adapter/Driver/Mysqli/TableGatewayTest.php
+++ b/test/integration/Adapter/Driver/Mysqli/TableGatewayTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ZendIntegrationTest\Db\Adapter\Driver\Mysqli;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\TableGateway\TableGateway;
+
+class TableGatewayTest extends TestCase
+{
+    use TraitSetup;
+
+    /**
+     * @see https://github.com/zendframework/zend-db/issues/330
+     */
+    public function testSelectWithEmptyCurrentWithBufferResult()
+    {
+        $adapter = new Adapter([
+            'driver'   => 'mysqli',
+            'database' => $this->variables['database'],
+            'hostname' => $this->variables['hostname'],
+            'username' => $this->variables['username'],
+            'password' => $this->variables['password'],
+            'options'   => ['buffer_results' => true]
+        ]);
+        $tableGateway = new TableGateway('test', $adapter);
+        $rowset = $tableGateway->select('id = 0');
+
+        $this->assertNull($rowset->current());
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-db/issues/330
+     */
+    public function testSelectWithEmptyCurrentWithoutBufferResult()
+    {
+        $adapter = new Adapter([
+            'driver'   => 'mysqli',
+            'database' => $this->variables['database'],
+            'hostname' => $this->variables['hostname'],
+            'username' => $this->variables['username'],
+            'password' => $this->variables['password'],
+            'options'   => ['buffer_results' => false]
+        ]);
+        $tableGateway = new TableGateway('test', $adapter);
+        $rowset = $tableGateway->select('id = 0');
+
+        $this->assertNull($rowset->current());
+    }
+}

--- a/test/integration/Adapter/Driver/Mysqli/TraitSetup.php
+++ b/test/integration/Adapter/Driver/Mysqli/TraitSetup.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendIntegrationTest\Db\Adapter\Driver\Mysqli;
+
+trait TraitSetup
+{
+    protected $variables = [
+        'hostname' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_HOSTNAME',
+        'username' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_USERNAME',
+        'password' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_PASSWORD',
+        'database' => 'TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL_DATABASE',
+    ];
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_DB_ADAPTER_DRIVER_MYSQL')) {
+            $this->markTestSkipped('Mysqli integration test disabled');
+        }
+
+        if (! extension_loaded('mysqli')) {
+            $this->fail('The phpunit group integration-mysqli was enabled, but the extension is not loaded.');
+        }
+
+        foreach ($this->variables as $name => $value) {
+            if (! getenv($value)) {
+                $this->markTestSkipped(sprintf(
+                    'Missing required variable %s from phpunit.xml for this integration test',
+                    $value
+                ));
+            }
+            $this->variables[$name] = getenv($value);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #330 and replaces #334. I focused the fix directly on mysqli adapter, and not anymore in the `Zend\Db\ResultSet\AbstractResultSet::current()`, changing the default `$currentData` value of `Zend\Db\Adapter\Driver\Mysqli\ResultSet` to NULL. I added an integration test to reproduce the issue, as reported in #330.