### PR TITLE
restore missing use file

### DIFF
--- a/docs/book/table-gateway.md
+++ b/docs/book/table-gateway.md
@@ -144,7 +144,7 @@ This allows for a wider array of possible mixing and matching of features to
 achieve a particular behavior that needs to be attained to make the base
 implementation of `TableGateway` useful for a particular problem.
 
-With the `TableGateway` object, features should be injected though the
+With the `TableGateway` object, features should be injected through the
 constructor. The constructor can take features in 3 different forms:
 
 - as a single `Feature` instance

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\TableGateway;
 
 use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\ResultSet\ResultSetInterface;
 use Zend\Db\Sql\Delete;
 use Zend\Db\Sql\Insert;

--- a/src/TableGateway/Feature/MetadataFeature.php
+++ b/src/TableGateway/Feature/MetadataFeature.php
@@ -73,11 +73,11 @@ class MetadataFeature extends AbstractFeature
             throw new Exception\RuntimeException('A primary key for this column could not be found in the metadata.');
         }
 
-        $pkck = $pkck->getColumns();
-        if (count($pkc) === 1) {
-            $primaryKey = $pkck[0];
+        $pkcColumns = $pkc->getColumns();
+        if (count($pkcColumns) === 1) {
+            $primaryKey = $pkcColumns[0];
         } else {
-            $primaryKey = $pkc;
+            $primaryKey = $pkcColumns;
         }
 
         $this->sharedData['metadata']['primaryKey'] = $primaryKey;

--- a/test/unit/TableGateway/AbstractTableGatewayTest.php
+++ b/test/unit/TableGateway/AbstractTableGatewayTest.php
@@ -84,6 +84,8 @@ class AbstractTableGatewayTest extends TestCase
                 ->getMock()
         ));
 
+        $this->mockFeatureSet = $this->getMockBuilder('Zend\Db\TableGateway\Feature\FeatureSet')->getMock();
+
         $this->table = $this->getMockForAbstractClass(
             'Zend\Db\TableGateway\AbstractTableGateway'
             //array('getTable')
@@ -103,6 +105,9 @@ class AbstractTableGatewayTest extends TestCase
                     break;
                 case 'sql':
                     $tgPropReflection->setValue($this->table, $this->mockSql);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($this->table, $this->mockFeatureSet);
                     break;
             }
         }
@@ -367,6 +372,30 @@ class AbstractTableGatewayTest extends TestCase
     {
         $this->table->insert(['foo' => 'bar']);
         self::assertEquals(10, $this->table->getLastInsertValue());
+    }
+
+    public function testInitializeBuildsAResultSet()
+    {
+        $stub = $this->getMockForAbstractClass(AbstractTableGateway::class);
+
+        $tgReflection = new \ReflectionClass('Zend\Db\TableGateway\AbstractTableGateway');
+        foreach ($tgReflection->getProperties() as $tgPropReflection) {
+            $tgPropReflection->setAccessible(true);
+            switch ($tgPropReflection->getName()) {
+                case 'table':
+                    $tgPropReflection->setValue($stub, 'foo');
+                    break;
+                case 'adapter':
+                    $tgPropReflection->setValue($stub, $this->mockAdapter);
+                    break;
+                case 'featureSet':
+                    $tgPropReflection->setValue($stub, $this->mockFeatureSet);
+                    break;
+            }
+        }
+
+        $stub->initialize();
+        $this->assertInstanceOf(ResultSet::class, $stub->getResultSetPrototype());
     }
 
     /**

--- a/test/unit/TableGateway/Feature/MetadataFeatureTest.php
+++ b/test/unit/TableGateway/Feature/MetadataFeatureTest.php
@@ -10,7 +10,12 @@
 namespace ZendTest\Db\TableGateway\Feature;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Zend\Db\Metadata\MetadataInterface;
 use Zend\Db\Metadata\Object\ConstraintObject;
+use Zend\Db\Metadata\Object\TableObject;
+use Zend\Db\Metadata\Object\ViewObject;
+use Zend\Db\TableGateway\AbstractTableGateway;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
 
 class MetadataFeatureTest extends TestCase
@@ -21,7 +26,6 @@ class MetadataFeatureTest extends TestCase
     public function testPostInitialize()
     {
         $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
-
         $metadataMock = $this->getMockBuilder('Zend\Db\Metadata\MetadataInterface')->getMock();
         $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
 
@@ -36,5 +40,86 @@ class MetadataFeatureTest extends TestCase
         $feature->postInitialize();
 
         self::assertEquals(['id', 'name'], $tableGatewayMock->getColumns());
+    }
+
+    public function testPostInitializeRecordsPrimaryKeyColumnToSharedMetadata()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new TableObject('foo')));
+
+
+        $constraintObject = new ConstraintObject('id_pk', 'table');
+        $constraintObject->setColumns(['id']);
+        $constraintObject->setType('PRIMARY KEY');
+
+        $metadataMock->expects($this->any())->method('getConstraints')->will($this->returnValue([$constraintObject]));
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $r = new ReflectionProperty(MetadataFeature::class, 'sharedData');
+        $r->setAccessible(true);
+        $sharedData = $r->getValue($feature);
+
+        self::assertTrue(
+            isset($sharedData['metadata']['primaryKey']),
+            'Shared data must have metadata entry for primary key'
+        );
+        self::assertSame($sharedData['metadata']['primaryKey'], 'id');
+    }
+
+    public function testPostInitializeRecordsListOfColumnsInPrimaryKeyToSharedMetadata()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new TableObject('foo')));
+
+
+        $constraintObject = new ConstraintObject('id_pk', 'table');
+        $constraintObject->setColumns(['composite', 'id']);
+        $constraintObject->setType('PRIMARY KEY');
+
+        $metadataMock->expects($this->any())->method('getConstraints')->will($this->returnValue([$constraintObject]));
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $r = new ReflectionProperty(MetadataFeature::class, 'sharedData');
+        $r->setAccessible(true);
+        $sharedData = $r->getValue($feature);
+
+        self::assertTrue(
+            isset($sharedData['metadata']['primaryKey']),
+            'Shared data must have metadata entry for primary key'
+        );
+        self::assertEquals($sharedData['metadata']['primaryKey'], ['composite', 'id']);
+    }
+
+    public function testPostInitializeSkipsPrimaryKeyCheckIfNotTable()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new ViewObject('foo')));
+
+        $metadataMock->expects($this->never())->method('getConstraints');
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
     }
 }


### PR DESCRIPTION
This problem always appears when using AbstractTableGateway
In src/TableGateway/AbstractTableGateway.php:110 a new instance of ResultSet is created without a use statement.
Use statement added again - ResultSet can now be created correctly