### PR TITLE
Fix undefined variable bug in MetadataFeature

### DIFF
--- a/src/TableGateway/Feature/MetadataFeature.php
+++ b/src/TableGateway/Feature/MetadataFeature.php
@@ -73,11 +73,11 @@ class MetadataFeature extends AbstractFeature
             throw new Exception\RuntimeException('A primary key for this column could not be found in the metadata.');
         }
 
-        $pkck = $pkck->getColumns();
-        if (count($pkc) === 1) {
-            $primaryKey = $pkck[0];
+        $pkcColumns = $pkc->getColumns();
+        if (count($pkcColumns) === 1) {
+            $primaryKey = $pkcColumns[0];
         } else {
-            $primaryKey = $pkc;
+            $primaryKey = $pkcColumns;
         }
 
         $this->sharedData['metadata']['primaryKey'] = $primaryKey;

--- a/test/unit/TableGateway/Feature/MetadataFeatureTest.php
+++ b/test/unit/TableGateway/Feature/MetadataFeatureTest.php
@@ -10,7 +10,12 @@
 namespace ZendTest\Db\TableGateway\Feature;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Zend\Db\Metadata\MetadataInterface;
 use Zend\Db\Metadata\Object\ConstraintObject;
+use Zend\Db\Metadata\Object\TableObject;
+use Zend\Db\Metadata\Object\ViewObject;
+use Zend\Db\TableGateway\AbstractTableGateway;
 use Zend\Db\TableGateway\Feature\MetadataFeature;
 
 class MetadataFeatureTest extends TestCase
@@ -21,7 +26,6 @@ class MetadataFeatureTest extends TestCase
     public function testPostInitialize()
     {
         $tableGatewayMock = $this->getMockForAbstractClass('Zend\Db\TableGateway\AbstractTableGateway');
-
         $metadataMock = $this->getMockBuilder('Zend\Db\Metadata\MetadataInterface')->getMock();
         $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
 
@@ -36,5 +40,86 @@ class MetadataFeatureTest extends TestCase
         $feature->postInitialize();
 
         self::assertEquals(['id', 'name'], $tableGatewayMock->getColumns());
+    }
+
+    public function testPostInitializeRecordsPrimaryKeyColumnToSharedMetadata()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new TableObject('foo')));
+
+
+        $constraintObject = new ConstraintObject('id_pk', 'table');
+        $constraintObject->setColumns(['id']);
+        $constraintObject->setType('PRIMARY KEY');
+
+        $metadataMock->expects($this->any())->method('getConstraints')->will($this->returnValue([$constraintObject]));
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $r = new ReflectionProperty(MetadataFeature::class, 'sharedData');
+        $r->setAccessible(true);
+        $sharedData = $r->getValue($feature);
+
+        self::assertTrue(
+            isset($sharedData['metadata']['primaryKey']),
+            'Shared data must have metadata entry for primary key'
+        );
+        self::assertSame($sharedData['metadata']['primaryKey'], 'id');
+    }
+
+    public function testPostInitializeRecordsListOfColumnsInPrimaryKeyToSharedMetadata()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new TableObject('foo')));
+
+
+        $constraintObject = new ConstraintObject('id_pk', 'table');
+        $constraintObject->setColumns(['composite', 'id']);
+        $constraintObject->setType('PRIMARY KEY');
+
+        $metadataMock->expects($this->any())->method('getConstraints')->will($this->returnValue([$constraintObject]));
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
+
+        $r = new ReflectionProperty(MetadataFeature::class, 'sharedData');
+        $r->setAccessible(true);
+        $sharedData = $r->getValue($feature);
+
+        self::assertTrue(
+            isset($sharedData['metadata']['primaryKey']),
+            'Shared data must have metadata entry for primary key'
+        );
+        self::assertEquals($sharedData['metadata']['primaryKey'], ['composite', 'id']);
+    }
+
+    public function testPostInitializeSkipsPrimaryKeyCheckIfNotTable()
+    {
+        /** @var AbstractTableGateway $tableGatewayMock */
+        $tableGatewayMock = $this->getMockForAbstractClass(AbstractTableGateway::class);
+        $metadataMock = $this->getMockBuilder(MetadataInterface::class)->getMock();
+        $metadataMock->expects($this->any())->method('getColumnNames')->will($this->returnValue(['id', 'name']));
+        $metadataMock->expects($this->any())
+            ->method('getTable')
+            ->will($this->returnValue(new ViewObject('foo')));
+
+        $metadataMock->expects($this->never())->method('getConstraints');
+
+        $feature = new MetadataFeature($metadataMock);
+        $feature->setTableGateway($tableGatewayMock);
+        $feature->postInitialize();
     }
 }


### PR DESCRIPTION
This PR fixes bug introduced in #315 
It was not released and exists only in master/develop branches as such no changelog entry is needed.
This PR restores original behavior, adds tests and reapplies changes from #315 properly.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
    Bug is invoked when metadata information is recorded into shared data of the TDG metadata feature
  - [x] Detail the original, incorrect behavior.
    Undefined variable error is thrown and invalid data is written into shared data
  - [x] Detail the new, expected behavior.
    Proper behavior restored, column name or list of columns in primary key are written into shared data
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

Supersedes #340  