### PR TITLE
Add Expression as allowed value to Select

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -328,7 +328,7 @@ class Select extends AbstractPreparableSql
     }
 
     /**
-     * @param string|array $order
+     * @param string|array|Expression $order
      * @return self Provides a fluent interface
      */
     public function order($order)


### PR DESCRIPTION
Static analysis fails if an Expression object is passed to some methods, thus the updated docblock.