### PR TITLE
add support for `IN (NULL)` for empty value-set

### DIFF
--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -127,7 +127,7 @@ class In extends AbstractExpression implements PredicateInterface
             $valuePlaceholders = $countValues > 0 ? array_fill(0, $countValues, '%s') : [];
             $specification = vsprintf(
                 $this->specification,
-                [$identifierSpecFragment, '(' . implode(', ', $valuePlaceholders) . ')']
+                [$identifierSpecFragment, '(' . (implode(', ', $valuePlaceholders) ?: 'NULL') . ')']
             );
         }
 

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -125,9 +125,13 @@ class In extends AbstractExpression implements PredicateInterface
             }
             $countValues = count($values);
             $valuePlaceholders = $countValues > 0 ? array_fill(0, $countValues, '%s') : [];
+            $inValueList = implode(', ', $valuePlaceholders);
+            if ('' === $inValueList) {
+                $inValueList = 'NULL';
+            }
             $specification = vsprintf(
                 $this->specification,
-                [$identifierSpecFragment, '(' . (implode(', ', $valuePlaceholders) ?: 'NULL') . ')']
+                [$identifierSpecFragment, '(' . $inValueList . ')']
             );
         }
 

--- a/test/unit/Sql/Predicate/InTest.php
+++ b/test/unit/Sql/Predicate/InTest.php
@@ -94,7 +94,7 @@ class InTest extends TestCase
         $select = new Select;
         $in = new In('foo', []);
         $expected = [[
-            '%s IN ()',
+            '%s IN (NULL)',
             ['foo'],
             [$in::TYPE_IDENTIFIER]
         ]];


### PR DESCRIPTION
Calling `$expression->in($identifier, [])` results in an invalid SQL string.
For an empty valueSet we should return a never-satisfied `(IVL)` condition string such as `(NULL)`.