### PR TITLE
Hotfix #355: Named params in subquery - limit and offset

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -716,7 +716,7 @@ class Select extends AbstractPreparableSql
         if ($parameterContainer) {
             $paramPrefix = $this->processInfo['paramPrefix'];
             $parameterContainer->offsetSet($paramPrefix . 'limit', $this->limit, ParameterContainer::TYPE_INTEGER);
-            return [$driver->formatParameterName('limit')];
+            return [$driver->formatParameterName($paramPrefix . 'limit')];
         }
         return [$platform->quoteValue($this->limit)];
     }
@@ -732,7 +732,7 @@ class Select extends AbstractPreparableSql
         if ($parameterContainer) {
             $paramPrefix = $this->processInfo['paramPrefix'];
             $parameterContainer->offsetSet($paramPrefix . 'offset', $this->offset, ParameterContainer::TYPE_INTEGER);
-            return [$driver->formatParameterName('offset')];
+            return [$driver->formatParameterName($paramPrefix . 'offset')];
         }
 
         return [$platform->quoteValue($this->offset)];


### PR DESCRIPTION
Set proper names for limit and offset parameters in subquery - add prefix.

Fixes #355

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
  - [X] Detail the original, incorrect behavior.
  - [X] Detail the new, expected behavior.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [X] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

/cc @rjd22 @tptrixtop @Ocramius 