### PR TITLE
update pdo-result current() doc-block

### DIFF
--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -136,7 +136,7 @@ class Result implements Iterator, ResultInterface
 
     /**
      * Get the data
-     * @return array
+     * @return mixed
      */
     public function current()
     {


### PR DESCRIPTION
`PDOStatement::fetch(...)` returns mixed type(s), `false` on failure (The doc-block for the returned property is correctly set to `mixed`)