### PR TITLE
Refactor of `Zend\Db\Metadata` for 3.0.0

### DIFF
--- a/3.0.0.md
+++ b/3.0.0.md
@@ -36,4 +36,4 @@ be compatible with return hint declaration of `Zend\Db\Metadata\Source\AbstractS
 
 - Zend\Db\Metadata\Source\SqliteMetadata
 
-`parseTrigger()` now possibly return `array|null` instead of `array|void`
+`parseView()` and `parseTrigger()` now possibly return `array|null` instead of `array|void`

--- a/3.0.0.md
+++ b/3.0.0.md
@@ -28,3 +28,12 @@ Changed `setDriver(DriverInterface $driver)` for all the following platforms:
     - Zend\Db\Adapter\Platform\Postgresql
     - Zend\Db\Adapter\Platform\Sqlite
     - Zend\Db\Adapter\Platform\SqlServer
+
+- Zend\Db\Adapter\Adapter\OracleMetadata
+
+Removed return statement of `loadColumnData()` and `loadTableNameData()` to
+be compatible with return hint declaration of `Zend\Db\Metadata\Source\AbstractSource`
+
+- Zend\Db\Metadata\Source\SqliteMetadata
+
+`parseTrigger()` now possibly return `array|null` instead of `array|void`

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -171,10 +171,10 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     /**
      * Get feature
      *
-     * @param $name
+     * @param string $name
      * @return AbstractFeature|false
      */
-    public function getFeature($name)
+    public function getFeature(string $name)
     {
         if (isset($this->features[$name])) {
             return $this->features[$name];

--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -263,7 +263,7 @@ class Connection extends AbstractConnection
     /**
      * {@inheritDoc}
      */
-    public function getLastGeneratedValue($name = null): string
+    public function getLastGeneratedValue(string $name = null): string
     {
         if ($name === null) {
             return '';

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata;
 

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -24,7 +24,7 @@ class Metadata implements MetadataInterface
     /**
      * @var MetadataInterface
      */
-    protected $source = null;
+    protected $source;
 
     /**
      * Constructor
@@ -39,7 +39,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTables($schema = null, $includeViews = false) : array
+    public function getTables(?string $schema = null, bool $includeViews = false) : array
     {
         return $this->source->getTables($schema, $includeViews);
     }
@@ -47,7 +47,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViews($schema = null) : array
+    public function getViews(?string $schema = null) : array
     {
         return $this->source->getViews($schema);
     }
@@ -55,7 +55,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggers($schema = null) : array
+    public function getTriggers(?string $schema = null) : array
     {
         return $this->source->getTriggers($schema);
     }
@@ -63,7 +63,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraints($table, $schema = null) : array
+    public function getConstraints(string $table, ?string $schema = null) : array
     {
         return $this->source->getConstraints($table, $schema);
     }
@@ -71,7 +71,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumns($table, $schema = null) : array
+    public function getColumns(string $table, ?string $schema = null) : array
     {
         return $this->source->getColumns($table, $schema);
     }
@@ -79,7 +79,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraintKeys($constraint, $table, $schema = null) : array
+    public function getConstraintKeys($constraint, $table, ?string $schema = null) : array
     {
         return $this->source->getConstraintKeys($constraint, $table, $schema);
     }
@@ -87,7 +87,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject
+    public function getConstraint($constraintName, $table, ?string $schema = null) : ConstraintObject
     {
         return $this->source->getConstraint($constraintName, $table, $schema);
     }
@@ -103,7 +103,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTableNames($schema = null, $includeViews = false) : array
+    public function getTableNames(?string $schema = null, bool $includeViews = false) : array
     {
         return $this->source->getTableNames($schema, $includeViews);
     }
@@ -111,7 +111,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTable($tableName, $schema = null) : TableObject
+    public function getTable($tableName, ?string $schema = null) : TableObject
     {
         return $this->source->getTable($tableName, $schema);
     }
@@ -119,7 +119,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViewNames($schema = null) : array
+    public function getViewNames(?string $schema = null) : array
     {
         return $this->source->getViewNames($schema);
     }
@@ -127,7 +127,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getView($viewName, $schema = null) : ViewObject
+    public function getView($viewName, ?string $schema = null) : ViewObject
     {
         return $this->source->getView($viewName, $schema);
     }
@@ -135,7 +135,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggerNames($schema = null) : array
+    public function getTriggerNames(?string $schema = null) : array
     {
         return $this->source->getTriggerNames($schema);
     }
@@ -143,7 +143,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTrigger($triggerName, $schema = null) : TriggerObject
+    public function getTrigger($triggerName, ?string $schema = null) : TriggerObject
     {
         return $this->source->getTrigger($triggerName, $schema);
     }
@@ -151,7 +151,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnNames($table, $schema = null) : array
+    public function getColumnNames(string $table, ?string $schema = null) : array
     {
         return $this->source->getColumnNames($table, $schema);
     }
@@ -159,7 +159,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn($columnName, $table, $schema = null) : ColumnObject
+    public function getColumn($columnName, $table, ?string $schema = null) : ColumnObject
     {
         return $this->source->getColumn($columnName, $table, $schema);
     }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -3,13 +3,18 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\Db\Metadata;
 
 use Zend\Db\Adapter\Adapter;
+use Zend\Db\Metadata\Object\ColumnObject;
+use Zend\Db\Metadata\Object\ConstraintObject;
+use Zend\Db\Metadata\Object\TableObject;
+use Zend\Db\Metadata\Object\TriggerObject;
+use Zend\Db\Metadata\Object\ViewObject;
 
 /**
  * @deprecated Use Zend\Db\Metadata\Source\Factory::createSourceFromAdapter($adapter)
@@ -34,7 +39,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTables($schema = null, $includeViews = false)
+    public function getTables($schema = null, $includeViews = false) : array
     {
         return $this->source->getTables($schema, $includeViews);
     }
@@ -42,7 +47,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViews($schema = null)
+    public function getViews($schema = null) : array
     {
         return $this->source->getViews($schema);
     }
@@ -50,7 +55,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggers($schema = null)
+    public function getTriggers($schema = null) : array
     {
         return $this->source->getTriggers($schema);
     }
@@ -58,7 +63,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraints($table, $schema = null)
+    public function getConstraints($table, $schema = null) : array
     {
         return $this->source->getConstraints($table, $schema);
     }
@@ -66,7 +71,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumns($table, $schema = null)
+    public function getColumns($table, $schema = null) : array
     {
         return $this->source->getColumns($table, $schema);
     }
@@ -74,7 +79,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraintKeys($constraint, $table, $schema = null)
+    public function getConstraintKeys($constraint, $table, $schema = null) : array
     {
         return $this->source->getConstraintKeys($constraint, $table, $schema);
     }
@@ -82,7 +87,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraint($constraintName, $table, $schema = null)
+    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject
     {
         return $this->source->getConstraint($constraintName, $table, $schema);
     }
@@ -90,7 +95,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getSchemas()
+    public function getSchemas() : array
     {
         return $this->source->getSchemas();
     }
@@ -98,7 +103,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTableNames($schema = null, $includeViews = false)
+    public function getTableNames($schema = null, $includeViews = false) : array
     {
         return $this->source->getTableNames($schema, $includeViews);
     }
@@ -106,7 +111,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTable($tableName, $schema = null)
+    public function getTable($tableName, $schema = null) : TableObject
     {
         return $this->source->getTable($tableName, $schema);
     }
@@ -114,7 +119,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViewNames($schema = null)
+    public function getViewNames($schema = null) : array
     {
         return $this->source->getViewNames($schema);
     }
@@ -122,7 +127,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getView($viewName, $schema = null)
+    public function getView($viewName, $schema = null) : ViewObject
     {
         return $this->source->getView($viewName, $schema);
     }
@@ -130,7 +135,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggerNames($schema = null)
+    public function getTriggerNames($schema = null) : array
     {
         return $this->source->getTriggerNames($schema);
     }
@@ -138,7 +143,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTrigger($triggerName, $schema = null)
+    public function getTrigger($triggerName, $schema = null) : TriggerObject
     {
         return $this->source->getTrigger($triggerName, $schema);
     }
@@ -146,7 +151,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnNames($table, $schema = null)
+    public function getColumnNames($table, $schema = null) : array
     {
         return $this->source->getColumnNames($table, $schema);
     }
@@ -154,7 +159,7 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn($columnName, $table, $schema = null)
+    public function getColumn($columnName, $table, $schema = null) : ColumnObject
     {
         return $this->source->getColumn($columnName, $table, $schema);
     }

--- a/src/Metadata/MetadataInterface.php
+++ b/src/Metadata/MetadataInterface.php
@@ -9,6 +9,13 @@
 
 namespace Zend\Db\Metadata;
 
+use Zend\Db\Metadata\Object\ColumnObject;
+use Zend\Db\Metadata\Object\ConstraintKeyObject;
+use Zend\Db\Metadata\Object\ConstraintObject;
+use Zend\Db\Metadata\Object\TableObject;
+use Zend\Db\Metadata\Object\TriggerObject;
+use Zend\Db\Metadata\Object\ViewObject;
+
 interface MetadataInterface
 {
     /**
@@ -16,7 +23,7 @@ interface MetadataInterface
      *
      * @return string[]
      */
-    public function getSchemas();
+    public function getSchemas() : array;
 
     /**
      * Get table names.
@@ -25,25 +32,25 @@ interface MetadataInterface
      * @param bool $includeViews
      * @return string[]
      */
-    public function getTableNames($schema = null, $includeViews = false);
+    public function getTableNames($schema = null, $includeViews = false) : array;
 
     /**
      * Get tables.
      *
      * @param null|string $schema
      * @param bool $includeViews
-     * @return Object\TableObject[]
+     * @return TableObject[]
      */
-    public function getTables($schema = null, $includeViews = false);
+    public function getTables($schema = null, $includeViews = false) : array;
 
     /**
      * Get table
      *
      * @param string $tableName
      * @param null|string $schema
-     * @return Object\TableObject
+     * @return TableObject
      */
-    public function getTable($tableName, $schema = null);
+    public function getTable($tableName, $schema = null) : TableObject;
 
     /**
      * Get view names
@@ -51,24 +58,24 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getViewNames($schema = null);
+    public function getViewNames($schema = null) : array;
 
     /**
      * Get views
      *
      * @param null|string $schema
-     * @return Object\ViewObject[]
+     * @return ViewObject[]
      */
-    public function getViews($schema = null);
+    public function getViews($schema = null) : array;
 
     /**
      * Get view
      *
      * @param string $viewName
      * @param null|string $schema
-     * @return Object\ViewObject
+     * @return ViewObject
      */
-    public function getView($viewName, $schema = null);
+    public function getView($viewName, $schema = null) : ViewObject;
 
     /**
      * Get column names
@@ -77,16 +84,16 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getColumnNames($table, $schema = null);
+    public function getColumnNames($table, $schema = null) : array;
 
     /**
      * Get columns
      *
      * @param string $table
      * @param null|string $schema
-     * @return Object\ColumnObject[]
+     * @return ColumnObject[]
      */
-    public function getColumns($table, $schema = null);
+    public function getColumns($table, $schema = null) : array;
 
     /**
      * Get column
@@ -94,18 +101,18 @@ interface MetadataInterface
      * @param string $columnName
      * @param string $table
      * @param null|string $schema
-     * @return Object\ColumnObject
+     * @return ColumnObject
      */
-    public function getColumn($columnName, $table, $schema = null);
+    public function getColumn($columnName, $table, $schema = null) : ColumnObject;
 
     /**
      * Get constraints
      *
      * @param string $table
      * @param null|string $schema
-     * @return Object\ConstraintObject[]
+     * @return ConstraintObject[]
      */
-    public function getConstraints($table, $schema = null);
+    public function getConstraints($table, $schema = null) : array;
 
     /**
      * Get constraint
@@ -113,9 +120,9 @@ interface MetadataInterface
      * @param string $constraintName
      * @param string $table
      * @param null|string $schema
-     * @return Object\ConstraintObject
+     * @return ConstraintObject
      */
-    public function getConstraint($constraintName, $table, $schema = null);
+    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject;
 
     /**
      * Get constraint keys
@@ -123,9 +130,9 @@ interface MetadataInterface
      * @param string $constraint
      * @param string $table
      * @param null|string $schema
-     * @return Object\ConstraintKeyObject[]
+     * @return ConstraintKeyObject[]
      */
-    public function getConstraintKeys($constraint, $table, $schema = null);
+    public function getConstraintKeys($constraint, $table, $schema = null) : array;
 
     /**
      * Get trigger names
@@ -133,22 +140,22 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getTriggerNames($schema = null);
+    public function getTriggerNames($schema = null) : array;
 
     /**
      * Get triggers
      *
      * @param null|string $schema
-     * @return Object\TriggerObject[]
+     * @return TriggerObject[]
      */
-    public function getTriggers($schema = null);
+    public function getTriggers($schema = null) : array;
 
     /**
      * Get trigger
      *
      * @param string $triggerName
      * @param null|string $schema
-     * @return Object\TriggerObject
+     * @return TriggerObject
      */
-    public function getTrigger($triggerName, $schema = null);
+    public function getTrigger($triggerName, $schema = null) : TriggerObject;
 }

--- a/src/Metadata/MetadataInterface.php
+++ b/src/Metadata/MetadataInterface.php
@@ -32,7 +32,7 @@ interface MetadataInterface
      * @param bool $includeViews
      * @return string[]
      */
-    public function getTableNames($schema = null, $includeViews = false) : array;
+    public function getTableNames(?string $schema = null, bool $includeViews = false) : array;
 
     /**
      * Get tables.
@@ -41,7 +41,7 @@ interface MetadataInterface
      * @param bool $includeViews
      * @return TableObject[]
      */
-    public function getTables($schema = null, $includeViews = false) : array;
+    public function getTables(?string $schema = null, bool $includeViews = false) : array;
 
     /**
      * Get table
@@ -50,7 +50,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return TableObject
      */
-    public function getTable($tableName, $schema = null) : TableObject;
+    public function getTable(string $tableName, ?string $schema = null) : TableObject;
 
     /**
      * Get view names
@@ -58,7 +58,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getViewNames($schema = null) : array;
+    public function getViewNames(?string $schema = null) : array;
 
     /**
      * Get views
@@ -66,7 +66,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ViewObject[]
      */
-    public function getViews($schema = null) : array;
+    public function getViews(?string $schema = null) : array;
 
     /**
      * Get view
@@ -75,7 +75,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ViewObject
      */
-    public function getView($viewName, $schema = null) : ViewObject;
+    public function getView(string $viewName, ?string $schema = null) : ViewObject;
 
     /**
      * Get column names
@@ -84,7 +84,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getColumnNames($table, $schema = null) : array;
+    public function getColumnNames(string $table, ?string $schema = null) : array;
 
     /**
      * Get columns
@@ -93,7 +93,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ColumnObject[]
      */
-    public function getColumns($table, $schema = null) : array;
+    public function getColumns(string $table, ?string $schema = null) : array;
 
     /**
      * Get column
@@ -103,7 +103,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ColumnObject
      */
-    public function getColumn($columnName, $table, $schema = null) : ColumnObject;
+    public function getColumn(string $columnName, string $table, ?string $schema = null) : ColumnObject;
 
     /**
      * Get constraints
@@ -112,7 +112,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ConstraintObject[]
      */
-    public function getConstraints($table, $schema = null) : array;
+    public function getConstraints(string $table, ?string $schema = null) : array;
 
     /**
      * Get constraint
@@ -122,7 +122,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ConstraintObject
      */
-    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject;
+    public function getConstraint(string $constraintName, string $table, ?string $schema = null) : ConstraintObject;
 
     /**
      * Get constraint keys
@@ -132,7 +132,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return ConstraintKeyObject[]
      */
-    public function getConstraintKeys($constraint, $table, $schema = null) : array;
+    public function getConstraintKeys(string $constraint, string $table, ?string $schema = null) : array;
 
     /**
      * Get trigger names
@@ -140,7 +140,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return string[]
      */
-    public function getTriggerNames($schema = null) : array;
+    public function getTriggerNames(?string $schema = null) : array;
 
     /**
      * Get triggers
@@ -148,7 +148,7 @@ interface MetadataInterface
      * @param null|string $schema
      * @return TriggerObject[]
      */
-    public function getTriggers($schema = null) : array;
+    public function getTriggers(?string $schema = null) : array;
 
     /**
      * Get trigger
@@ -157,5 +157,5 @@ interface MetadataInterface
      * @param null|string $schema
      * @return TriggerObject
      */
-    public function getTrigger($triggerName, $schema = null) : TriggerObject;
+    public function getTrigger(string $triggerName, ?string $schema = null) : TriggerObject;
 }

--- a/src/Metadata/MetadataInterface.php
+++ b/src/Metadata/MetadataInterface.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata;
 

--- a/src/Metadata/Object/AbstractTableObject.php
+++ b/src/Metadata/Object/AbstractTableObject.php
@@ -15,36 +15,34 @@ abstract class AbstractTableObject
      *
      * @var string
      */
-    protected $name = null;
+    protected $name = '';
 
     /**
      *
      * @var string
      */
-    protected $type = null;
+    protected $type = '';
 
     /**
      *
      * @var array
      */
-    protected $columns = null;
+    protected $columns = [];
 
     /**
      *
      * @var array
      */
-    protected $constraints = null;
+    protected $constraints = [];
 
     /**
      * Constructor
      *
      * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name = '')
     {
-        if ($name) {
-            $this->setName($name);
-        }
+        $this->setName($name);
     }
 
     /**
@@ -52,7 +50,7 @@ abstract class AbstractTableObject
      *
      * @param array $columns
      */
-    public function setColumns(array $columns)
+    public function setColumns(array $columns) : void
     {
         $this->columns = $columns;
     }
@@ -62,7 +60,7 @@ abstract class AbstractTableObject
      *
      * @return array
      */
-    public function getColumns()
+    public function getColumns() : array
     {
         return $this->columns;
     }
@@ -72,7 +70,7 @@ abstract class AbstractTableObject
      *
      * @param array $constraints
      */
-    public function setConstraints($constraints)
+    public function setConstraints(array $constraints) : void
     {
         $this->constraints = $constraints;
     }
@@ -82,7 +80,7 @@ abstract class AbstractTableObject
      *
      * @return array
      */
-    public function getConstraints()
+    public function getConstraints() : array
     {
         return $this->constraints;
     }
@@ -92,7 +90,7 @@ abstract class AbstractTableObject
      *
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name) : void
     {
         $this->name = $name;
     }
@@ -102,7 +100,7 @@ abstract class AbstractTableObject
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }

--- a/src/Metadata/Object/AbstractTableObject.php
+++ b/src/Metadata/Object/AbstractTableObject.php
@@ -12,25 +12,21 @@ namespace Zend\Db\Metadata\Object;
 abstract class AbstractTableObject
 {
     /**
-     *
      * @var string
      */
     protected $name = '';
 
     /**
-     *
      * @var string
      */
     protected $type = '';
 
     /**
-     *
      * @var array
      */
     protected $columns = [];
 
     /**
-     *
      * @var array
      */
     protected $constraints = [];

--- a/src/Metadata/Object/AbstractTableObject.php
+++ b/src/Metadata/Object/AbstractTableObject.php
@@ -11,11 +11,6 @@ namespace Zend\Db\Metadata\Object;
 
 abstract class AbstractTableObject
 {
-    /*
-    protected $catalogName = null;
-    protected $schemaName = null;
-    */
-
     /**
      *
      * @var string

--- a/src/Metadata/Object/AbstractTableObject.php
+++ b/src/Metadata/Object/AbstractTableObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -12,79 +12,66 @@ namespace Zend\Db\Metadata\Object;
 class ColumnObject
 {
     /**
-     *
      * @var string
      */
     protected $name = '';
 
     /**
-     *
      * @var string
      */
     protected $tableName = '';
 
     /**
-     *
      * @var string
      */
     protected $schemaName = '';
 
     /**
-     *
      * @var int|null
      */
     protected $ordinalPosition;
 
     /**
-     *
      * @var string
      */
     protected $columnDefault = '';
 
     /**
-     *
      * @var bool
      */
     protected $isNullable = false;
 
     /**
-     *
      * @var string
      */
     protected $dataType = '';
 
     /**
-     *
      * @var int|null
      */
     protected $characterMaximumLength;
 
     /**
-     *
      * @var int|null
      */
     protected $characterOctetLength;
 
     /**
-     *
      * @var int|null
      */
     protected $numericPrecision;
 
     /**
-     *
      * @var int|null
      */
     protected $numericScale;
 
     /**
-     *
      * @var bool
      */
     protected $numericUnsigned = false;
 
     /**
-     *
      * @var array
      */
     protected $errata = [];

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -15,73 +15,73 @@ class ColumnObject
      *
      * @var string
      */
-    protected $name = null;
+    protected $name = '';
 
     /**
      *
      * @var string
      */
-    protected $tableName = null;
+    protected $tableName = '';
 
     /**
      *
      * @var string
      */
-    protected $schemaName = null;
+    protected $schemaName = '';
 
     /**
      *
-     * @var
+     * @var int|null
      */
-    protected $ordinalPosition = null;
+    protected $ordinalPosition;
 
     /**
      *
      * @var string
      */
-    protected $columnDefault = null;
+    protected $columnDefault = '';
 
     /**
      *
      * @var bool
      */
-    protected $isNullable = null;
+    protected $isNullable = false;
 
     /**
      *
      * @var string
      */
-    protected $dataType = null;
+    protected $dataType = '';
 
     /**
      *
-     * @var int
+     * @var int|null
      */
-    protected $characterMaximumLength = null;
+    protected $characterMaximumLength;
 
     /**
      *
-     * @var int
+     * @var int|null
      */
-    protected $characterOctetLength = null;
+    protected $characterOctetLength;
 
     /**
      *
-     * @var int
+     * @var int|null
      */
-    protected $numericPrecision = null;
+    protected $numericPrecision;
 
     /**
      *
-     * @var int
+     * @var int|null
      */
-    protected $numericScale = null;
+    protected $numericScale;
 
     /**
      *
      * @var bool
      */
-    protected $numericUnsigned = null;
+    protected $numericUnsigned = false;
 
     /**
      *
@@ -96,7 +96,7 @@ class ColumnObject
      * @param string $tableName
      * @param string $schemaName
      */
-    public function __construct($name, $tableName, $schemaName = null)
+    public function __construct(string $name, string $tableName, string $schemaName = '')
     {
         $this->setName($name);
         $this->setTableName($tableName);
@@ -108,7 +108,7 @@ class ColumnObject
      *
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name) : void
     {
         $this->name = $name;
     }
@@ -118,7 +118,7 @@ class ColumnObject
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -128,7 +128,7 @@ class ColumnObject
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName() : string
     {
         return $this->tableName;
     }
@@ -139,7 +139,7 @@ class ColumnObject
      * @param string $tableName
      * @return self Provides a fluent interface
      */
-    public function setTableName($tableName)
+    public function setTableName(string $tableName) : self
     {
         $this->tableName = $tableName;
         return $this;
@@ -150,7 +150,7 @@ class ColumnObject
      *
      * @param string $schemaName
      */
-    public function setSchemaName($schemaName)
+    public function setSchemaName(string $schemaName) : void
     {
         $this->schemaName = $schemaName;
     }
@@ -160,7 +160,7 @@ class ColumnObject
      *
      * @return string
      */
-    public function getSchemaName()
+    public function getSchemaName() : string
     {
         return $this->schemaName;
     }
@@ -168,7 +168,7 @@ class ColumnObject
     /**
      * @return int $ordinalPosition
      */
-    public function getOrdinalPosition()
+    public function getOrdinalPosition() : ?int
     {
         return $this->ordinalPosition;
     }
@@ -177,7 +177,7 @@ class ColumnObject
      * @param int $ordinalPosition to set
      * @return self Provides a fluent interface
      */
-    public function setOrdinalPosition($ordinalPosition)
+    public function setOrdinalPosition(?int $ordinalPosition) : self
     {
         $this->ordinalPosition = $ordinalPosition;
         return $this;
@@ -186,16 +186,16 @@ class ColumnObject
     /**
      * @return null|string the $columnDefault
      */
-    public function getColumnDefault()
+    public function getColumnDefault() : ?string
     {
         return $this->columnDefault;
     }
 
     /**
-     * @param mixed $columnDefault to set
+     * @param string $columnDefault to set
      * @return self Provides a fluent interface
      */
-    public function setColumnDefault($columnDefault)
+    public function setColumnDefault(string $columnDefault) : self
     {
         $this->columnDefault = $columnDefault;
         return $this;
@@ -204,7 +204,7 @@ class ColumnObject
     /**
      * @return bool $isNullable
      */
-    public function getIsNullable()
+    public function getIsNullable() : bool
     {
         return $this->isNullable;
     }
@@ -213,7 +213,7 @@ class ColumnObject
      * @param bool $isNullable to set
      * @return self Provides a fluent interface
      */
-    public function setIsNullable($isNullable)
+    public function setIsNullable(bool $isNullable) : self
     {
         $this->isNullable = $isNullable;
         return $this;
@@ -222,7 +222,7 @@ class ColumnObject
     /**
      * @return bool $isNullable
      */
-    public function isNullable()
+    public function isNullable() : bool
     {
         return $this->isNullable;
     }
@@ -230,7 +230,7 @@ class ColumnObject
     /**
      * @return null|string the $dataType
      */
-    public function getDataType()
+    public function getDataType() : ?string
     {
         return $this->dataType;
     }
@@ -239,7 +239,7 @@ class ColumnObject
      * @param string $dataType the $dataType to set
      * @return self Provides a fluent interface
      */
-    public function setDataType($dataType)
+    public function setDataType(string $dataType) : self
     {
         $this->dataType = $dataType;
         return $this;
@@ -248,16 +248,16 @@ class ColumnObject
     /**
      * @return int|null the $characterMaximumLength
      */
-    public function getCharacterMaximumLength()
+    public function getCharacterMaximumLength() : ?int
     {
         return $this->characterMaximumLength;
     }
 
     /**
-     * @param int $characterMaximumLength the $characterMaximumLength to set
+     * @param int|null $characterMaximumLength the $characterMaximumLength to set
      * @return self Provides a fluent interface
      */
-    public function setCharacterMaximumLength($characterMaximumLength)
+    public function setCharacterMaximumLength(?int $characterMaximumLength) : self
     {
         $this->characterMaximumLength = $characterMaximumLength;
         return $this;
@@ -266,16 +266,16 @@ class ColumnObject
     /**
      * @return int|null the $characterOctetLength
      */
-    public function getCharacterOctetLength()
+    public function getCharacterOctetLength() : ?int
     {
         return $this->characterOctetLength;
     }
 
     /**
-     * @param int $characterOctetLength the $characterOctetLength to set
+     * @param int|null $characterOctetLength the $characterOctetLength to set
      * @return self Provides a fluent interface
      */
-    public function setCharacterOctetLength($characterOctetLength)
+    public function setCharacterOctetLength(?int $characterOctetLength) : self
     {
         $this->characterOctetLength = $characterOctetLength;
         return $this;
@@ -284,16 +284,16 @@ class ColumnObject
     /**
      * @return int the $numericPrecision
      */
-    public function getNumericPrecision()
+    public function getNumericPrecision() : ?int
     {
         return $this->numericPrecision;
     }
 
     /**
-     * @param int $numericPrecision the $numericPrevision to set
+     * @param int|null $numericPrecision the $numericPrevision to set
      * @return self Provides a fluent interface
      */
-    public function setNumericPrecision($numericPrecision)
+    public function setNumericPrecision(?int $numericPrecision) : self
     {
         $this->numericPrecision = $numericPrecision;
         return $this;
@@ -302,7 +302,7 @@ class ColumnObject
     /**
      * @return int the $numericScale
      */
-    public function getNumericScale()
+    public function getNumericScale() : ?int
     {
         return $this->numericScale;
     }
@@ -311,7 +311,7 @@ class ColumnObject
      * @param int $numericScale the $numericScale to set
      * @return self Provides a fluent interface
      */
-    public function setNumericScale($numericScale)
+    public function setNumericScale(?int $numericScale) : self
     {
         $this->numericScale = $numericScale;
         return $this;
@@ -320,7 +320,7 @@ class ColumnObject
     /**
      * @return bool
      */
-    public function getNumericUnsigned()
+    public function getNumericUnsigned() : bool
     {
         return $this->numericUnsigned;
     }
@@ -329,7 +329,7 @@ class ColumnObject
      * @param  bool $numericUnsigned
      * @return self Provides a fluent interface
      */
-    public function setNumericUnsigned($numericUnsigned)
+    public function setNumericUnsigned(bool $numericUnsigned) : self
     {
         $this->numericUnsigned = $numericUnsigned;
         return $this;
@@ -338,7 +338,7 @@ class ColumnObject
     /**
      * @return bool
      */
-    public function isNumericUnsigned()
+    public function isNumericUnsigned() : bool
     {
         return $this->numericUnsigned;
     }
@@ -346,7 +346,7 @@ class ColumnObject
     /**
      * @return array the $errata
      */
-    public function getErratas()
+    public function getErratas() : array
     {
         return $this->errata;
     }
@@ -355,7 +355,7 @@ class ColumnObject
      * @param array $erratas
      * @return self Provides a fluent interface
      */
-    public function setErratas(array $erratas)
+    public function setErratas(array $erratas) : self
     {
         foreach ($erratas as $name => $value) {
             $this->setErrata($name, $value);
@@ -367,12 +367,11 @@ class ColumnObject
      * @param string $errataName
      * @return mixed
      */
-    public function getErrata($errataName)
+    public function getErrata(string $errataName)
     {
         if (array_key_exists($errataName, $this->errata)) {
             return $this->errata[$errataName];
         }
-        return;
     }
 
     /**
@@ -380,7 +379,7 @@ class ColumnObject
      * @param mixed $errataValue
      * @return self Provides a fluent interface
      */
-    public function setErrata($errataName, $errataValue)
+    public function setErrata(string $errataName, $errataValue) : self
     {
         $this->errata[$errataName] = $errataValue;
         return $this;

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -21,56 +21,56 @@ class ConstraintKeyObject
      *
      * @var string
      */
-    protected $columnName = null;
+    protected $columnName = '';
 
     /**
      *
-     * @var int
+     * @var int|null
      */
-    protected $ordinalPosition = null;
+    protected $ordinalPosition;
 
     /**
      *
      * @var bool
      */
-    protected $positionInUniqueConstraint = null;
+    protected $positionInUniqueConstraint = false;
 
     /**
      *
      * @var string
      */
-    protected $referencedTableSchema = null;
+    protected $referencedTableSchema = '';
 
     /**
      *
      * @var string
      */
-    protected $referencedTableName = null;
+    protected $referencedTableName = '';
 
     /**
      *
      * @var string
      */
-    protected $referencedColumnName = null;
+    protected $referencedColumnName = '';
 
     /**
      *
      * @var string
      */
-    protected $foreignKeyUpdateRule = null;
+    protected $foreignKeyUpdateRule = '';
 
     /**
      *
      * @var string
      */
-    protected $foreignKeyDeleteRule = null;
+    protected $foreignKeyDeleteRule = '';
 
     /**
      * Constructor
      *
      * @param string $column
      */
-    public function __construct($column)
+    public function __construct(string $column)
     {
         $this->setColumnName($column);
     }
@@ -80,7 +80,7 @@ class ConstraintKeyObject
      *
      * @return string
      */
-    public function getColumnName()
+    public function getColumnName() : string
     {
         return $this->columnName;
     }
@@ -91,7 +91,7 @@ class ConstraintKeyObject
      * @param  string $columnName
      * @return self Provides a fluent interface
      */
-    public function setColumnName($columnName)
+    public function setColumnName(string $columnName) : self
     {
         $this->columnName = $columnName;
         return $this;
@@ -100,9 +100,9 @@ class ConstraintKeyObject
     /**
      * Get ordinal position
      *
-     * @return int
+     * @return int|null
      */
-    public function getOrdinalPosition()
+    public function getOrdinalPosition() : ?int
     {
         return $this->ordinalPosition;
     }
@@ -113,7 +113,7 @@ class ConstraintKeyObject
      * @param  int $ordinalPosition
      * @return self Provides a fluent interface
      */
-    public function setOrdinalPosition($ordinalPosition)
+    public function setOrdinalPosition($ordinalPosition) : self
     {
         $this->ordinalPosition = $ordinalPosition;
         return $this;
@@ -124,7 +124,7 @@ class ConstraintKeyObject
      *
      * @return bool
      */
-    public function getPositionInUniqueConstraint()
+    public function getPositionInUniqueConstraint() : bool
     {
         return $this->positionInUniqueConstraint;
     }
@@ -135,18 +135,18 @@ class ConstraintKeyObject
      * @param  bool $positionInUniqueConstraint
      * @return self Provides a fluent interface
      */
-    public function setPositionInUniqueConstraint($positionInUniqueConstraint)
+    public function setPositionInUniqueConstraint(bool $positionInUniqueConstraint) : self
     {
         $this->positionInUniqueConstraint = $positionInUniqueConstraint;
         return $this;
     }
 
     /**
-     * Get referencred table schema
+     * Get referenced table schema
      *
      * @return string
      */
-    public function getReferencedTableSchema()
+    public function getReferencedTableSchema() : string
     {
         return $this->referencedTableSchema;
     }
@@ -157,7 +157,7 @@ class ConstraintKeyObject
      * @param string $referencedTableSchema
      * @return self Provides a fluent interface
      */
-    public function setReferencedTableSchema($referencedTableSchema)
+    public function setReferencedTableSchema($referencedTableSchema) : self
     {
         $this->referencedTableSchema = $referencedTableSchema;
         return $this;
@@ -168,7 +168,7 @@ class ConstraintKeyObject
      *
      * @return string
      */
-    public function getReferencedTableName()
+    public function getReferencedTableName() : string
     {
         return $this->referencedTableName;
     }
@@ -179,7 +179,7 @@ class ConstraintKeyObject
      * @param  string $referencedTableName
      * @return self Provides a fluent interface
      */
-    public function setReferencedTableName($referencedTableName)
+    public function setReferencedTableName(string $referencedTableName) : self
     {
         $this->referencedTableName = $referencedTableName;
         return $this;
@@ -190,7 +190,7 @@ class ConstraintKeyObject
      *
      * @return string
      */
-    public function getReferencedColumnName()
+    public function getReferencedColumnName() : string
     {
         return $this->referencedColumnName;
     }
@@ -201,7 +201,7 @@ class ConstraintKeyObject
      * @param  string $referencedColumnName
      * @return self Provides a fluent interface
      */
-    public function setReferencedColumnName($referencedColumnName)
+    public function setReferencedColumnName(string $referencedColumnName) : self
     {
         $this->referencedColumnName = $referencedColumnName;
         return $this;
@@ -212,7 +212,7 @@ class ConstraintKeyObject
      *
      * @param string $foreignKeyUpdateRule
      */
-    public function setForeignKeyUpdateRule($foreignKeyUpdateRule)
+    public function setForeignKeyUpdateRule($foreignKeyUpdateRule) : void
     {
         $this->foreignKeyUpdateRule = $foreignKeyUpdateRule;
     }
@@ -222,7 +222,7 @@ class ConstraintKeyObject
      *
      * @return string
      */
-    public function getForeignKeyUpdateRule()
+    public function getForeignKeyUpdateRule() : string
     {
         return $this->foreignKeyUpdateRule;
     }
@@ -232,7 +232,7 @@ class ConstraintKeyObject
      *
      * @param string $foreignKeyDeleteRule
      */
-    public function setForeignKeyDeleteRule($foreignKeyDeleteRule)
+    public function setForeignKeyDeleteRule($foreignKeyDeleteRule) : void
     {
         $this->foreignKeyDeleteRule = $foreignKeyDeleteRule;
     }
@@ -242,7 +242,7 @@ class ConstraintKeyObject
      *
      * @return string
      */
-    public function getForeignKeyDeleteRule()
+    public function getForeignKeyDeleteRule() : string
     {
         return $this->foreignKeyDeleteRule;
     }

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -18,49 +18,41 @@ class ConstraintKeyObject
     public const FK_SET_DEFAULT = 'SET DEFAULT';
 
     /**
-     *
      * @var string
      */
     protected $columnName = '';
 
     /**
-     *
      * @var int|null
      */
     protected $ordinalPosition;
 
     /**
-     *
      * @var bool
      */
     protected $positionInUniqueConstraint = false;
 
     /**
-     *
      * @var string
      */
     protected $referencedTableSchema = '';
 
     /**
-     *
      * @var string
      */
     protected $referencedTableName = '';
 
     /**
-     *
      * @var string
      */
     protected $referencedColumnName = '';
 
     /**
-     *
      * @var string
      */
     protected $foreignKeyUpdateRule = '';
 
     /**
-     *
      * @var string
      */
     protected $foreignKeyDeleteRule = '';

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -11,11 +11,11 @@ namespace Zend\Db\Metadata\Object;
 
 class ConstraintKeyObject
 {
-    const FK_CASCADE = 'CASCADE';
-    const FK_SET_NULL = 'SET NULL';
-    const FK_NO_ACTION = 'NO ACTION';
-    const FK_RESTRICT = 'RESTRICT';
-    const FK_SET_DEFAULT = 'SET DEFAULT';
+    public const FK_CASCADE = 'CASCADE';
+    public const FK_SET_NULL = 'SET NULL';
+    public const FK_NO_ACTION = 'NO ACTION';
+    public const FK_RESTRICT = 'RESTRICT';
+    public const FK_SET_DEFAULT = 'SET DEFAULT';
 
     /**
      *

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -15,26 +15,26 @@ class ConstraintObject
      *
      * @var string
      */
-    protected $name = null;
+    protected $name = '';
 
     /**
      *
      * @var string
      */
-    protected $tableName = null;
+    protected $tableName = '';
 
     /**
      *
      * @var string
      */
-    protected $schemaName = null;
+    protected $schemaName = '';
 
     /**
      * One of "PRIMARY KEY", "UNIQUE", "FOREIGN KEY", or "CHECK"
      *
      * @var string
      */
-    protected $type = null;
+    protected $type = '';
 
     /**
      *
@@ -48,49 +48,49 @@ class ConstraintObject
      *
      * @var string
      */
-    protected $referencedTableSchema;
+    protected $referencedTableSchema = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $referencedTableName;
+    protected $referencedTableName = '';
 
     /**
      *
      *
      * @var string[]
      */
-    protected $referencedColumns;
+    protected $referencedColumns = [];
 
     /**
      *
      *
      * @var string
      */
-    protected $matchOption;
+    protected $matchOption = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $updateRule;
+    protected $updateRule = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $deleteRule;
+    protected $deleteRule = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $checkClause;
+    protected $checkClause = '';
 
     /**
      * Constructor
@@ -99,7 +99,7 @@ class ConstraintObject
      * @param string $tableName
      * @param string $schemaName
      */
-    public function __construct($name, $tableName, $schemaName = null)
+    public function __construct(string $name, string $tableName, string $schemaName = '')
     {
         $this->setName($name);
         $this->setTableName($tableName);
@@ -111,7 +111,7 @@ class ConstraintObject
      *
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name) : void
     {
         $this->name = $name;
     }
@@ -121,7 +121,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -131,7 +131,7 @@ class ConstraintObject
      *
      * @param string $schemaName
      */
-    public function setSchemaName($schemaName)
+    public function setSchemaName($schemaName) : void
     {
         $this->schemaName = $schemaName;
     }
@@ -141,7 +141,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getSchemaName()
+    public function getSchemaName() : string
     {
         return $this->schemaName;
     }
@@ -151,7 +151,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName() : string
     {
         return $this->tableName;
     }
@@ -162,7 +162,7 @@ class ConstraintObject
      * @param  string $tableName
      * @return self Provides a fluent interface
      */
-    public function setTableName($tableName)
+    public function setTableName($tableName) : self
     {
         $this->tableName = $tableName;
         return $this;
@@ -173,7 +173,7 @@ class ConstraintObject
      *
      * @param string $type
      */
-    public function setType($type)
+    public function setType($type) : void
     {
         $this->type = $type;
     }
@@ -183,12 +183,12 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getType()
+    public function getType() : string
     {
         return $this->type;
     }
 
-    public function hasColumns()
+    public function hasColumns() : bool
     {
         return (! empty($this->columns));
     }
@@ -198,7 +198,7 @@ class ConstraintObject
      *
      * @return string[]
      */
-    public function getColumns()
+    public function getColumns() : array
     {
         return $this->columns;
     }
@@ -209,7 +209,7 @@ class ConstraintObject
      * @param string[] $columns
      * @return self Provides a fluent interface
      */
-    public function setColumns(array $columns)
+    public function setColumns(array $columns) : self
     {
         $this->columns = $columns;
         return $this;
@@ -220,7 +220,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getReferencedTableSchema()
+    public function getReferencedTableSchema() : string
     {
         return $this->referencedTableSchema;
     }
@@ -231,7 +231,7 @@ class ConstraintObject
      * @param string $referencedTableSchema
      * @return self Provides a fluent interface
      */
-    public function setReferencedTableSchema($referencedTableSchema)
+    public function setReferencedTableSchema($referencedTableSchema) : self
     {
         $this->referencedTableSchema = $referencedTableSchema;
         return $this;
@@ -242,7 +242,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getReferencedTableName()
+    public function getReferencedTableName() : string
     {
         return $this->referencedTableName;
     }
@@ -253,7 +253,7 @@ class ConstraintObject
      * @param string $referencedTableName
      * @return self Provides a fluent interface
      */
-    public function setReferencedTableName($referencedTableName)
+    public function setReferencedTableName($referencedTableName) : self
     {
         $this->referencedTableName = $referencedTableName;
         return $this;
@@ -264,7 +264,7 @@ class ConstraintObject
      *
      * @return string[]
      */
-    public function getReferencedColumns()
+    public function getReferencedColumns() : array
     {
         return $this->referencedColumns;
     }
@@ -275,7 +275,7 @@ class ConstraintObject
      * @param string[] $referencedColumns
      * @return self Provides a fluent interface
      */
-    public function setReferencedColumns(array $referencedColumns)
+    public function setReferencedColumns(array $referencedColumns) : self
     {
         $this->referencedColumns = $referencedColumns;
         return $this;
@@ -286,7 +286,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getMatchOption()
+    public function getMatchOption() : string
     {
         return $this->matchOption;
     }
@@ -297,7 +297,7 @@ class ConstraintObject
      * @param string $matchOption
      * @return self Provides a fluent interface
      */
-    public function setMatchOption($matchOption)
+    public function setMatchOption($matchOption) : self
     {
         $this->matchOption = $matchOption;
         return $this;
@@ -308,7 +308,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getUpdateRule()
+    public function getUpdateRule() : string
     {
         return $this->updateRule;
     }
@@ -319,7 +319,7 @@ class ConstraintObject
      * @param string $updateRule
      * @return self Provides a fluent interface
      */
-    public function setUpdateRule($updateRule)
+    public function setUpdateRule($updateRule) : self
     {
         $this->updateRule = $updateRule;
         return $this;
@@ -330,7 +330,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getDeleteRule()
+    public function getDeleteRule() : string
     {
         return $this->deleteRule;
     }
@@ -341,7 +341,7 @@ class ConstraintObject
      * @param string $deleteRule
      * @return self Provides a fluent interface
      */
-    public function setDeleteRule($deleteRule)
+    public function setDeleteRule($deleteRule) : self
     {
         $this->deleteRule = $deleteRule;
         return $this;
@@ -352,7 +352,7 @@ class ConstraintObject
      *
      * @return string
      */
-    public function getCheckClause()
+    public function getCheckClause() : string
     {
         return $this->checkClause;
     }
@@ -363,7 +363,7 @@ class ConstraintObject
      * @param string $checkClause
      * @return self Provides a fluent interface
      */
-    public function setCheckClause($checkClause)
+    public function setCheckClause($checkClause) : self
     {
         $this->checkClause = $checkClause;
         return $this;
@@ -374,7 +374,7 @@ class ConstraintObject
      *
      * @return bool
      */
-    public function isPrimaryKey()
+    public function isPrimaryKey() : bool
     {
         return ('PRIMARY KEY' == $this->type);
     }
@@ -384,7 +384,7 @@ class ConstraintObject
      *
      * @return bool
      */
-    public function isUnique()
+    public function isUnique() : bool
     {
         return ('UNIQUE' == $this->type);
     }
@@ -394,7 +394,7 @@ class ConstraintObject
      *
      * @return bool
      */
-    public function isForeignKey()
+    public function isForeignKey() : bool
     {
         return ('FOREIGN KEY' == $this->type);
     }
@@ -404,7 +404,7 @@ class ConstraintObject
      *
      * @return bool
      */
-    public function isCheck()
+    public function isCheck() : bool
     {
         return ('CHECK' == $this->type);
     }

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -12,19 +12,16 @@ namespace Zend\Db\Metadata\Object;
 class ConstraintObject
 {
     /**
-     *
      * @var string
      */
     protected $name = '';
 
     /**
-     *
      * @var string
      */
     protected $tableName = '';
 
     /**
-     *
      * @var string
      */
     protected $schemaName = '';
@@ -37,57 +34,41 @@ class ConstraintObject
     protected $type = '';
 
     /**
-     *
-     *
      * @var string[]
      */
     protected $columns = [];
 
     /**
-     *
-     *
      * @var string
      */
     protected $referencedTableSchema = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $referencedTableName = '';
 
     /**
-     *
-     *
      * @var string[]
      */
     protected $referencedColumns = [];
 
     /**
-     *
-     *
      * @var string
      */
     protected $matchOption = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $updateRule = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $deleteRule = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $checkClause = '';

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -376,7 +376,7 @@ class ConstraintObject
      */
     public function isPrimaryKey() : bool
     {
-        return ('PRIMARY KEY' == $this->type);
+        return ('PRIMARY KEY' === $this->type);
     }
 
     /**
@@ -386,7 +386,7 @@ class ConstraintObject
      */
     public function isUnique() : bool
     {
-        return ('UNIQUE' == $this->type);
+        return ('UNIQUE' === $this->type);
     }
 
     /**
@@ -396,7 +396,7 @@ class ConstraintObject
      */
     public function isForeignKey() : bool
     {
-        return ('FOREIGN KEY' == $this->type);
+        return ('FOREIGN KEY' === $this->type);
     }
 
     /**
@@ -406,6 +406,6 @@ class ConstraintObject
      */
     public function isCheck() : bool
     {
-        return ('CHECK' == $this->type);
+        return ('CHECK' === $this->type);
     }
 }

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -190,7 +190,7 @@ class ConstraintObject
 
     public function hasColumns() : bool
     {
-        return (! empty($this->columns));
+        return ! empty($this->columns);
     }
 
     /**

--- a/src/Metadata/Object/TableObject.php
+++ b/src/Metadata/Object/TableObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 
+use DateTime;
+
 class TriggerObject
 {
     /**
@@ -16,103 +18,103 @@ class TriggerObject
      *
      * @var string
      */
-    protected $name;
+    protected $name = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $eventManipulation;
+    protected $eventManipulation = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $eventObjectCatalog;
+    protected $eventObjectCatalog = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $eventObjectSchema;
+    protected $eventObjectSchema = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $eventObjectTable;
+    protected $eventObjectTable = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionOrder;
+    protected $actionOrder = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionCondition;
+    protected $actionCondition = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionStatement;
+    protected $actionStatement = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionOrientation;
+    protected $actionOrientation = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionTiming;
+    protected $actionTiming = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionReferenceOldTable;
+    protected $actionReferenceOldTable = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionReferenceNewTable;
+    protected $actionReferenceNewTable = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionReferenceOldRow;
+    protected $actionReferenceOldRow = '';
 
     /**
      *
      *
      * @var string
      */
-    protected $actionReferenceNewRow;
+    protected $actionReferenceNewRow = '';
 
     /**
      *
      *
-     * @var \DateTime
+     * @var DateTime|null
      */
     protected $created;
 
@@ -121,7 +123,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -132,7 +134,7 @@ class TriggerObject
      * @param string $name
      * @return self Provides a fluent interface
      */
-    public function setName($name)
+    public function setName(string $name) : self
     {
         $this->name = $name;
         return $this;
@@ -143,7 +145,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getEventManipulation()
+    public function getEventManipulation() : string
     {
         return $this->eventManipulation;
     }
@@ -154,7 +156,7 @@ class TriggerObject
      * @param string $eventManipulation
      * @return self Provides a fluent interface
      */
-    public function setEventManipulation($eventManipulation)
+    public function setEventManipulation(string $eventManipulation) : self
     {
         $this->eventManipulation = $eventManipulation;
         return $this;
@@ -165,7 +167,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getEventObjectCatalog()
+    public function getEventObjectCatalog() : string
     {
         return $this->eventObjectCatalog;
     }
@@ -176,7 +178,7 @@ class TriggerObject
      * @param string $eventObjectCatalog
      * @return self Provides a fluent interface
      */
-    public function setEventObjectCatalog($eventObjectCatalog)
+    public function setEventObjectCatalog(string $eventObjectCatalog) : self
     {
         $this->eventObjectCatalog = $eventObjectCatalog;
         return $this;
@@ -187,7 +189,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getEventObjectSchema()
+    public function getEventObjectSchema() : string
     {
         return $this->eventObjectSchema;
     }
@@ -198,7 +200,7 @@ class TriggerObject
      * @param string $eventObjectSchema
      * @return self Provides a fluent interface
      */
-    public function setEventObjectSchema($eventObjectSchema)
+    public function setEventObjectSchema(string $eventObjectSchema) : self
     {
         $this->eventObjectSchema = $eventObjectSchema;
         return $this;
@@ -209,7 +211,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getEventObjectTable()
+    public function getEventObjectTable() : string
     {
         return $this->eventObjectTable;
     }
@@ -220,7 +222,7 @@ class TriggerObject
      * @param string $eventObjectTable
      * @return self Provides a fluent interface
      */
-    public function setEventObjectTable($eventObjectTable)
+    public function setEventObjectTable(string $eventObjectTable) : self
     {
         $this->eventObjectTable = $eventObjectTable;
         return $this;
@@ -231,7 +233,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionOrder()
+    public function getActionOrder() : string
     {
         return $this->actionOrder;
     }
@@ -242,7 +244,7 @@ class TriggerObject
      * @param string $actionOrder
      * @return self Provides a fluent interface
      */
-    public function setActionOrder($actionOrder)
+    public function setActionOrder(string $actionOrder) : self
     {
         $this->actionOrder = $actionOrder;
         return $this;
@@ -253,7 +255,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionCondition()
+    public function getActionCondition() : string
     {
         return $this->actionCondition;
     }
@@ -264,7 +266,7 @@ class TriggerObject
      * @param string $actionCondition
      * @return self Provides a fluent interface
      */
-    public function setActionCondition($actionCondition)
+    public function setActionCondition(string $actionCondition) : self
     {
         $this->actionCondition = $actionCondition;
         return $this;
@@ -275,7 +277,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionStatement()
+    public function getActionStatement() : string
     {
         return $this->actionStatement;
     }
@@ -286,7 +288,7 @@ class TriggerObject
      * @param string $actionStatement
      * @return self Provides a fluent interface
      */
-    public function setActionStatement($actionStatement)
+    public function setActionStatement(string $actionStatement) : self
     {
         $this->actionStatement = $actionStatement;
         return $this;
@@ -297,7 +299,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionOrientation()
+    public function getActionOrientation() : string
     {
         return $this->actionOrientation;
     }
@@ -308,7 +310,7 @@ class TriggerObject
      * @param string $actionOrientation
      * @return self Provides a fluent interface
      */
-    public function setActionOrientation($actionOrientation)
+    public function setActionOrientation(string $actionOrientation) : self
     {
         $this->actionOrientation = $actionOrientation;
         return $this;
@@ -319,7 +321,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionTiming()
+    public function getActionTiming() : string
     {
         return $this->actionTiming;
     }
@@ -330,7 +332,7 @@ class TriggerObject
      * @param string $actionTiming
      * @return self Provides a fluent interface
      */
-    public function setActionTiming($actionTiming)
+    public function setActionTiming(string $actionTiming) : self
     {
         $this->actionTiming = $actionTiming;
         return $this;
@@ -341,7 +343,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionReferenceOldTable()
+    public function getActionReferenceOldTable() : string
     {
         return $this->actionReferenceOldTable;
     }
@@ -352,7 +354,7 @@ class TriggerObject
      * @param string $actionReferenceOldTable
      * @return self Provides a fluent interface
      */
-    public function setActionReferenceOldTable($actionReferenceOldTable)
+    public function setActionReferenceOldTable(string $actionReferenceOldTable) : self
     {
         $this->actionReferenceOldTable = $actionReferenceOldTable;
         return $this;
@@ -363,7 +365,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionReferenceNewTable()
+    public function getActionReferenceNewTable() : string
     {
         return $this->actionReferenceNewTable;
     }
@@ -374,7 +376,7 @@ class TriggerObject
      * @param string $actionReferenceNewTable
      * @return self Provides a fluent interface
      */
-    public function setActionReferenceNewTable($actionReferenceNewTable)
+    public function setActionReferenceNewTable(string $actionReferenceNewTable) : self
     {
         $this->actionReferenceNewTable = $actionReferenceNewTable;
         return $this;
@@ -385,7 +387,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionReferenceOldRow()
+    public function getActionReferenceOldRow() : string
     {
         return $this->actionReferenceOldRow;
     }
@@ -396,7 +398,7 @@ class TriggerObject
      * @param string $actionReferenceOldRow
      * @return self Provides a fluent interface
      */
-    public function setActionReferenceOldRow($actionReferenceOldRow)
+    public function setActionReferenceOldRow(string $actionReferenceOldRow) : self
     {
         $this->actionReferenceOldRow = $actionReferenceOldRow;
         return $this;
@@ -407,7 +409,7 @@ class TriggerObject
      *
      * @return string
      */
-    public function getActionReferenceNewRow()
+    public function getActionReferenceNewRow() : string
     {
         return $this->actionReferenceNewRow;
     }
@@ -418,7 +420,7 @@ class TriggerObject
      * @param string $actionReferenceNewRow
      * @return self Provides a fluent interface
      */
-    public function setActionReferenceNewRow($actionReferenceNewRow)
+    public function setActionReferenceNewRow(string $actionReferenceNewRow) : self
     {
         $this->actionReferenceNewRow = $actionReferenceNewRow;
         return $this;
@@ -427,9 +429,9 @@ class TriggerObject
     /**
      * Get Created.
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getCreated()
+    public function getCreated(): ?DateTime
     {
         return $this->created;
     }
@@ -437,10 +439,10 @@ class TriggerObject
     /**
      * Set Created.
      *
-     * @param \DateTime $created
+     * @param DateTime $created
      * @return self Provides a fluent interface
      */
-    public function setCreated($created)
+    public function setCreated(?DateTime $created) : self
     {
         $this->created = $created;
         return $this;

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -14,106 +14,76 @@ use DateTime;
 class TriggerObject
 {
     /**
-     *
-     *
      * @var string
      */
     protected $name = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $eventManipulation = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $eventObjectCatalog = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $eventObjectSchema = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $eventObjectTable = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionOrder = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionCondition = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionStatement = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionOrientation = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionTiming = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionReferenceOldTable = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionReferenceNewTable = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionReferenceOldRow = '';
 
     /**
-     *
-     *
      * @var string
      */
     protected $actionReferenceNewRow = '';
 
     /**
-     *
-     *
      * @var DateTime|null
      */
     protected $created;

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Object;
 

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -11,8 +11,19 @@ namespace Zend\Db\Metadata\Object;
 
 class ViewObject extends AbstractTableObject
 {
+    /**
+     * @var string
+     */
     protected $viewDefinition = '';
+
+    /**
+     * @var string
+     */
     protected $checkOption = '';
+
+    /**
+     * @var bool
+     */
     protected $isUpdatable = false;
 
     /**
@@ -69,6 +80,9 @@ class ViewObject extends AbstractTableObject
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isUpdatable() : bool
     {
         return $this->isUpdatable;

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -11,14 +11,14 @@ namespace Zend\Db\Metadata\Object;
 
 class ViewObject extends AbstractTableObject
 {
-    protected $viewDefinition;
-    protected $checkOption;
-    protected $isUpdatable;
+    protected $viewDefinition = '';
+    protected $checkOption = '';
+    protected $isUpdatable = false;
 
     /**
      * @return string $viewDefinition
      */
-    public function getViewDefinition()
+    public function getViewDefinition() : string
     {
         return $this->viewDefinition;
     }
@@ -27,7 +27,7 @@ class ViewObject extends AbstractTableObject
      * @param string $viewDefinition to set
      * @return self Provides a fluent interface
      */
-    public function setViewDefinition($viewDefinition)
+    public function setViewDefinition(string $viewDefinition) : self
     {
         $this->viewDefinition = $viewDefinition;
         return $this;
@@ -36,7 +36,7 @@ class ViewObject extends AbstractTableObject
     /**
      * @return string $checkOption
      */
-    public function getCheckOption()
+    public function getCheckOption() : string
     {
         return $this->checkOption;
     }
@@ -45,7 +45,7 @@ class ViewObject extends AbstractTableObject
      * @param string $checkOption to set
      * @return self Provides a fluent interface
      */
-    public function setCheckOption($checkOption)
+    public function setCheckOption(string $checkOption) : self
     {
         $this->checkOption = $checkOption;
         return $this;
@@ -54,7 +54,7 @@ class ViewObject extends AbstractTableObject
     /**
      * @return bool $isUpdatable
      */
-    public function getIsUpdatable()
+    public function getIsUpdatable() : bool
     {
         return $this->isUpdatable;
     }
@@ -63,13 +63,13 @@ class ViewObject extends AbstractTableObject
      * @param bool $isUpdatable to set
      * @return self Provides a fluent interface
      */
-    public function setIsUpdatable($isUpdatable)
+    public function setIsUpdatable(bool $isUpdatable) : self
     {
         $this->isUpdatable = $isUpdatable;
         return $this;
     }
 
-    public function isUpdatable()
+    public function isUpdatable() : bool
     {
         return $this->isUpdatable;
     }

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -78,7 +78,7 @@ abstract class AbstractSource implements MetadataInterface
 
         $tableNames = [];
         foreach ($this->data['table_names'][$schema] as $tableName => $data) {
-            if ('BASE TABLE' == $data['table_type']) {
+            if ('BASE TABLE' === $data['table_type']) {
                 $tableNames[] = $tableName;
             }
         }
@@ -150,7 +150,7 @@ abstract class AbstractSource implements MetadataInterface
 
         $viewNames = [];
         foreach ($this->data['table_names'][$schema] as $tableName => $data) {
-            if ('VIEW' == $data['table_type']) {
+            if ('VIEW' === $data['table_type']) {
                 $viewNames[] = $tableName;
             }
         }
@@ -185,7 +185,7 @@ abstract class AbstractSource implements MetadataInterface
         $this->loadTableNameData($schema);
 
         $tableNames = $this->data['table_names'][$schema];
-        if (isset($tableNames[$viewName]) && 'VIEW' == $tableNames[$viewName]['table_type']) {
+        if (isset($tableNames[$viewName]) && 'VIEW' === $tableNames[$viewName]['table_type']) {
             return $this->getTable($viewName, $schema);
         }
         throw new \Exception('View "' . $viewName . '" does not exist');
@@ -341,7 +341,7 @@ abstract class AbstractSource implements MetadataInterface
         // organize references first
         $references = [];
         foreach ($this->data['constraint_references'][$schema] as $refKeyInfo) {
-            if ($refKeyInfo['constraint_name'] == $constraint) {
+            if ($refKeyInfo['constraint_name'] === $constraint) {
                 $references[$refKeyInfo['constraint_name']] = $refKeyInfo;
             }
         }
@@ -350,7 +350,7 @@ abstract class AbstractSource implements MetadataInterface
 
         $keys = [];
         foreach ($this->data['constraint_keys'][$schema] as $constraintKeyInfo) {
-            if ($constraintKeyInfo['table_name'] == $table && $constraintKeyInfo['constraint_name'] === $constraint) {
+            if ($constraintKeyInfo['table_name'] === $table && $constraintKeyInfo['constraint_name'] === $constraint) {
                 $keys[] = $key = new ConstraintKeyObject($constraintKeyInfo['column_name']);
                 $key->setOrdinalPosition($constraintKeyInfo['ordinal_position']);
                 if (isset($references[$constraint])) {

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -55,7 +55,7 @@ abstract class AbstractSource implements MetadataInterface
      * Get schemas
      *
      */
-    public function getSchemas()
+    public function getSchemas() : array
     {
         $this->loadSchemaData();
 
@@ -65,7 +65,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTableNames($schema = null, $includeViews = false)
+    public function getTableNames($schema = null, $includeViews = false) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -89,7 +89,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTables($schema = null, $includeViews = false)
+    public function getTables($schema = null, $includeViews = false) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -105,7 +105,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTable($tableName, $schema = null)
+    public function getTable($tableName, $schema = null) : TableObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -141,7 +141,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViewNames($schema = null)
+    public function getViewNames($schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -161,7 +161,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViews($schema = null)
+    public function getViews($schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -177,7 +177,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getView($viewName, $schema = null)
+    public function getView($viewName, $schema = null) : ViewObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -195,7 +195,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnNames($table, $schema = null)
+    public function getColumnNames($table, $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -213,7 +213,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumns($table, $schema = null)
+    public function getColumns($table, $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -231,7 +231,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn($columnName, $table, $schema = null)
+    public function getColumn($columnName, $table, $schema = null) : ColumnObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -275,7 +275,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraints($table, $schema = null)
+    public function getConstraints($table, $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -294,7 +294,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraint($constraintName, $table, $schema = null)
+    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -331,7 +331,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraintKeys($constraint, $table, $schema = null)
+    public function getConstraintKeys($constraint, $table, $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -371,7 +371,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggerNames($schema = null)
+    public function getTriggerNames($schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -385,7 +385,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggers($schema = null)
+    public function getTriggers($schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -401,7 +401,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTrigger($triggerName, $schema = null)
+    public function getTrigger($triggerName, $schema = null) : TriggerObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -442,7 +442,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $type
      * @param string $key ...
      */
-    protected function prepareDataHierarchy($type)
+    protected function prepareDataHierarchy($type) : void
     {
         $data = &$this->data;
         foreach (func_get_args() as $key) {
@@ -456,7 +456,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * Load schema data
      */
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
     }
 
@@ -465,7 +465,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -480,7 +480,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -495,7 +495,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema])) {
             return;
@@ -509,7 +509,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadConstraintDataKeys($schema)
+    protected function loadConstraintDataKeys($schema) : void
     {
         if (isset($this->data['constraint_keys'][$schema])) {
             return;
@@ -524,7 +524,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadConstraintReferences($table, $schema)
+    protected function loadConstraintReferences($table, $schema) : void
     {
         if (isset($this->data['constraint_references'][$schema])) {
             return;
@@ -538,7 +538,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -20,7 +20,7 @@ use Zend\Db\Metadata\Object\TriggerObject;
 
 abstract class AbstractSource implements MetadataInterface
 {
-    const DEFAULT_SCHEMA = '__DEFAULT_SCHEMA__';
+    public const DEFAULT_SCHEMA = '__DEFAULT_SCHEMA__';
 
     /**
      *

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -48,7 +48,7 @@ abstract class AbstractSource implements MetadataInterface
     public function __construct(Adapter $adapter)
     {
         $this->adapter = $adapter;
-        $this->defaultSchema = ($adapter->getCurrentSchema()) ?: self::DEFAULT_SCHEMA;
+        $this->defaultSchema = $adapter->getCurrentSchema() ?: self::DEFAULT_SCHEMA;
     }
 
     /**

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -23,19 +23,16 @@ abstract class AbstractSource implements MetadataInterface
     public const DEFAULT_SCHEMA = '__DEFAULT_SCHEMA__';
 
     /**
-     *
      * @var Adapter
      */
     protected $adapter;
 
     /**
-     *
      * @var string
      */
     protected $defaultSchema = '';
 
     /**
-     *
      * @var array
      */
     protected $data = [];

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -26,13 +26,13 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @var Adapter
      */
-    protected $adapter = null;
+    protected $adapter;
 
     /**
      *
      * @var string
      */
-    protected $defaultSchema = null;
+    protected $defaultSchema = '';
 
     /**
      *
@@ -52,8 +52,7 @@ abstract class AbstractSource implements MetadataInterface
     }
 
     /**
-     * Get schemas
-     *
+     * @inheritdoc
      */
     public function getSchemas() : array
     {
@@ -65,7 +64,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTableNames($schema = null, $includeViews = false) : array
+    public function getTableNames(?string $schema = null, bool $includeViews = false) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -89,7 +88,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTables($schema = null, $includeViews = false) : array
+    public function getTables(?string $schema = null, bool $includeViews = false) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -105,7 +104,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTable($tableName, $schema = null) : TableObject
+    public function getTable(string $tableName, ?string $schema = null) : TableObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -141,7 +140,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViewNames($schema = null) : array
+    public function getViewNames(?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -161,7 +160,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getViews($schema = null) : array
+    public function getViews(?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -177,7 +176,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getView($viewName, $schema = null) : ViewObject
+    public function getView(string $viewName, ?string $schema = null) : ViewObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -195,7 +194,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumnNames($table, $schema = null) : array
+    public function getColumnNames(string $table, ?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -213,7 +212,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumns($table, $schema = null) : array
+    public function getColumns(string $table, ?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -231,7 +230,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn($columnName, $table, $schema = null) : ColumnObject
+    public function getColumn(string $columnName, string $table, ?string $schema = null) : ColumnObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -275,7 +274,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraints($table, $schema = null) : array
+    public function getConstraints(string $table, ?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -294,7 +293,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraint($constraintName, $table, $schema = null) : ConstraintObject
+    public function getConstraint(string $constraintName, string $table, ?string $schema = null) : ConstraintObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -331,7 +330,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getConstraintKeys($constraint, $table, $schema = null) : array
+    public function getConstraintKeys(string $constraint, string $table, ?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -371,7 +370,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggerNames($schema = null) : array
+    public function getTriggerNames(?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -385,7 +384,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTriggers($schema = null) : array
+    public function getTriggers(?string $schema = null) : array
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -401,7 +400,7 @@ abstract class AbstractSource implements MetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getTrigger($triggerName, $schema = null) : TriggerObject
+    public function getTrigger(string $triggerName, ?string $schema = null) : TriggerObject
     {
         if ($schema === null) {
             $schema = $this->defaultSchema;
@@ -442,7 +441,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $type
      * @param string $key ...
      */
-    protected function prepareDataHierarchy($type) : void
+    protected function prepareDataHierarchy(string $type) : void
     {
         $data = &$this->data;
         foreach (func_get_args() as $key) {
@@ -465,7 +464,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -480,7 +479,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -495,7 +494,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema])) {
             return;
@@ -509,7 +508,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadConstraintDataKeys($schema) : void
+    protected function loadConstraintDataKeys(string $schema) : void
     {
         if (isset($this->data['constraint_keys'][$schema])) {
             return;
@@ -524,7 +523,7 @@ abstract class AbstractSource implements MetadataInterface
      * @param string $table
      * @param string $schema
      */
-    protected function loadConstraintReferences($table, $schema) : void
+    protected function loadConstraintReferences(string $table, string $schema) : void
     {
         if (isset($this->data['constraint_references'][$schema])) {
             return;
@@ -538,7 +537,7 @@ abstract class AbstractSource implements MetadataInterface
      *
      * @param string $schema
      */
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -439,7 +439,6 @@ abstract class AbstractSource implements MetadataInterface
      * Prepare data hierarchy
      *
      * @param string $type
-     * @param string $key ...
      */
     protected function prepareDataHierarchy(string $type) : void
     {

--- a/src/Metadata/Source/Factory.php
+++ b/src/Metadata/Source/Factory.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/Factory.php
+++ b/src/Metadata/Source/Factory.php
@@ -25,7 +25,7 @@ class Factory
      * @return MetadataInterface
      * @throws InvalidArgumentException If adapter platform name not recognized.
      */
-    public static function createSourceFromAdapter(Adapter $adapter)
+    public static function createSourceFromAdapter(Adapter $adapter) : MetadataInterface
     {
         $platformName = $adapter->getPlatform()->getName();
 

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -86,7 +86,7 @@ class MysqlMetadata extends AbstractSource
                 'table_type' => $row['TABLE_TYPE'],
                 'view_definition' => $row['VIEW_DEFINITION'],
                 'check_option' => $row['CHECK_OPTION'],
-                'is_updatable' => ('YES' == $row['IS_UPDATABLE']),
+                'is_updatable' => 'YES' == $row['IS_UPDATABLE'],
             ];
         }
 
@@ -161,13 +161,13 @@ class MysqlMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['ORDINAL_POSITION'],
                 'column_default'            => $row['COLUMN_DEFAULT'],
-                'is_nullable'               => ('YES' == $row['IS_NULLABLE']),
+                'is_nullable'               => 'YES' == $row['IS_NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['CHARACTER_MAXIMUM_LENGTH'],
                 'character_octet_length'    => $row['CHARACTER_OCTET_LENGTH'],
                 'numeric_precision'         => $row['NUMERIC_PRECISION'],
                 'numeric_scale'             => $row['NUMERIC_SCALE'],
-                'numeric_unsigned'          => (false !== strpos($row['COLUMN_TYPE'], 'unsigned')),
+                'numeric_unsigned'          => false !== strpos($row['COLUMN_TYPE'], 'unsigned'),
                 'erratas'                   => $erratas,
             ];
         }

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -13,6 +13,9 @@ use Zend\Db\Adapter\Adapter;
 
 class MysqlMetadata extends AbstractSource
 {
+    /**
+     * @inheritdoc
+     */
     protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
@@ -37,6 +40,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
@@ -93,6 +99,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
@@ -175,6 +184,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
@@ -284,6 +296,11 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
+    /**
+     * Load constraint data names
+     *
+     * @param string $schema
+     */
     protected function loadConstraintDataNames(string $schema) : void
     {
         if (isset($this->data['constraint_names'][$schema])) {
@@ -332,6 +349,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_names'][$schema] = $data;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintDataKeys(string $schema) : void
     {
         if (isset($this->data['constraint_keys'][$schema])) {
@@ -383,6 +403,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_keys'][$schema] = $data;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintReferences(string $table, string $schema) : void
     {
         parent::loadConstraintReferences($table, $schema);
@@ -441,6 +464,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_references'][$schema] = $data;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -70,7 +70,7 @@ class MysqlMetadata extends AbstractSource
              . ' WHERE ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
              . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
                   . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -86,7 +86,7 @@ class MysqlMetadata extends AbstractSource
                 'table_type' => $row['TABLE_TYPE'],
                 'view_definition' => $row['VIEW_DEFINITION'],
                 'check_option' => $row['CHECK_OPTION'],
-                'is_updatable' => 'YES' == $row['IS_UPDATABLE'],
+                'is_updatable' => 'YES' === $row['IS_UPDATABLE'],
             ];
         }
 
@@ -130,7 +130,7 @@ class MysqlMetadata extends AbstractSource
              . ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_NAME'])
              . '  = ' . $p->quoteTrustedValue($table);
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
                   . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -161,7 +161,7 @@ class MysqlMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['ORDINAL_POSITION'],
                 'column_default'            => $row['COLUMN_DEFAULT'],
-                'is_nullable'               => 'YES' == $row['IS_NULLABLE'],
+                'is_nullable'               => 'YES' === $row['IS_NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['CHARACTER_MAXIMUM_LENGTH'],
                 'character_octet_length'    => $row['CHARACTER_OCTET_LENGTH'],
@@ -230,7 +230,7 @@ class MysqlMetadata extends AbstractSource
              . ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
              . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -254,7 +254,7 @@ class MysqlMetadata extends AbstractSource
         foreach ($results->toArray() as $row) {
             if ($row['CONSTRAINT_NAME'] !== $realName) {
                 $realName = $row['CONSTRAINT_NAME'];
-                $isFK = ('FOREIGN KEY' == $row['CONSTRAINT_TYPE']);
+                $isFK = ('FOREIGN KEY' === $row['CONSTRAINT_TYPE']);
                 if ($isFK) {
                     $name = $realName;
                 } else {
@@ -314,7 +314,7 @@ class MysqlMetadata extends AbstractSource
         . ' WHERE ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
         . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -365,7 +365,7 @@ class MysqlMetadata extends AbstractSource
         . ' WHERE ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
         . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -423,7 +423,7 @@ class MysqlMetadata extends AbstractSource
         . 'WHERE ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
         . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -479,7 +479,7 @@ class MysqlMetadata extends AbstractSource
         . ' FROM ' . $p->quoteIdentifierChain(['INFORMATION_SCHEMA', 'TRIGGERS'])
         . ' WHERE ';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= $p->quoteIdentifier('TRIGGER_SCHEMA')
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -37,7 +37,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -93,7 +93,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -175,7 +175,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -284,7 +284,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadConstraintDataNames($schema) : void
+    protected function loadConstraintDataNames(string $schema) : void
     {
         if (isset($this->data['constraint_names'][$schema])) {
             return;
@@ -332,7 +332,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_names'][$schema] = $data;
     }
 
-    protected function loadConstraintDataKeys($schema) : void
+    protected function loadConstraintDataKeys(string $schema) : void
     {
         if (isset($this->data['constraint_keys'][$schema])) {
             return;
@@ -383,7 +383,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_keys'][$schema] = $data;
     }
 
-    protected function loadConstraintReferences($table, $schema) : void
+    protected function loadConstraintReferences(string $table, string $schema) : void
     {
         parent::loadConstraintReferences($table, $schema);
 
@@ -441,7 +441,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_references'][$schema] = $data;
     }
 
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/MysqlMetadata.php
+++ b/src/Metadata/Source/MysqlMetadata.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Adapter;
 
 class MysqlMetadata extends AbstractSource
 {
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
             return;
@@ -37,7 +37,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -93,7 +93,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -175,7 +175,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -284,7 +284,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadConstraintDataNames($schema)
+    protected function loadConstraintDataNames($schema) : void
     {
         if (isset($this->data['constraint_names'][$schema])) {
             return;
@@ -332,7 +332,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_names'][$schema] = $data;
     }
 
-    protected function loadConstraintDataKeys($schema)
+    protected function loadConstraintDataKeys($schema) : void
     {
         if (isset($this->data['constraint_keys'][$schema])) {
             return;
@@ -383,7 +383,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_keys'][$schema] = $data;
     }
 
-    protected function loadConstraintReferences($table, $schema)
+    protected function loadConstraintReferences($table, $schema) : void
     {
         parent::loadConstraintReferences($table, $schema);
 
@@ -441,7 +441,7 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_references'][$schema] = $data;
     }
 
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -63,7 +63,7 @@ class OracleMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['COLUMN_ID'],
                 'column_default'            => $row['DATA_DEFAULT'],
-                'is_nullable'               => 'Y' == $row['NULLABLE'],
+                'is_nullable'               => 'Y' === $row['NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['DATA_LENGTH'],
                 'character_octet_length'    => null,
@@ -147,14 +147,14 @@ class OracleMetadata extends AbstractSource
                     'table_name'      => $row['TABLE_NAME'],
                 ];
 
-                if ('C' == $row['CONSTRAINT_TYPE']) {
+                if ('C' === $row['CONSTRAINT_TYPE']) {
                     $constraints[$name]['CHECK_CLAUSE'] = $row['CHECK_CLAUSE'];
                     continue;
                 }
 
                 $constraints[$name]['columns'] = [];
 
-                $isFK = ('R' == $row['CONSTRAINT_TYPE']);
+                $isFK = ('R' === $row['CONSTRAINT_TYPE']);
                 if ($isFK) {
                     $constraints[$name]['referenced_table_schema'] = $row['REF_OWNER'];
                     $constraints[$name]['referenced_table_name']   = $row['REF_TABLE'];

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -19,7 +19,7 @@ class OracleMetadata extends AbstractSource
     /**
      * @var array
      */
-    protected $constraintTypeMap = [
+    protected static $constraintTypeMap = [
         'C' => 'CHECK',
         'P' => 'PRIMARY KEY',
         'R' => 'FOREIGN_KEY'

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -29,7 +29,7 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadColumnData()
      */
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -75,7 +75,6 @@ class OracleMetadata extends AbstractSource
         }
 
         $this->data['columns'][$schema][$table] = $columns;
-        return $this;
     }
 
     /**
@@ -84,7 +83,7 @@ class OracleMetadata extends AbstractSource
      * @param string $type
      * @return string
      */
-    protected function getConstraintType($type)
+    protected function getConstraintType($type) : string
     {
         if (isset($this->constraintTypeMap[$type])) {
             return $this->constraintTypeMap[$type];
@@ -97,7 +96,7 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadConstraintData()
      */
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -171,15 +170,13 @@ class OracleMetadata extends AbstractSource
                 $constraints[$name]['referenced_columns'][] = $row['REF_COLUMN'];
             }
         }
-
-        return $this;
     }
 
     /**
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadSchemaData()
      */
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
             return;
@@ -201,10 +198,10 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadTableNameData()
      */
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
-            return $this;
+            return;
         }
 
         $this->prepareDataHierarchy('table_names', $schema);
@@ -235,7 +232,6 @@ class OracleMetadata extends AbstractSource
         }
 
         $this->data['table_names'][$schema] = $tables;
-        return $this;
     }
 
     /**
@@ -245,7 +241,7 @@ class OracleMetadata extends AbstractSource
      *
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadTriggerData()
      */
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -63,7 +63,7 @@ class OracleMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['COLUMN_ID'],
                 'column_default'            => $row['DATA_DEFAULT'],
-                'is_nullable'               => ('Y' == $row['NULLABLE']),
+                'is_nullable'               => 'Y' == $row['NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['DATA_LENGTH'],
                 'character_octet_length'    => null,

--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -29,7 +29,7 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadColumnData()
      */
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -83,7 +83,7 @@ class OracleMetadata extends AbstractSource
      * @param string $type
      * @return string
      */
-    protected function getConstraintType($type) : string
+    protected function getConstraintType(string $type) : string
     {
         if (isset($this->constraintTypeMap[$type])) {
             return $this->constraintTypeMap[$type];
@@ -96,7 +96,7 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadConstraintData()
      */
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -198,7 +198,7 @@ class OracleMetadata extends AbstractSource
      * {@inheritdoc}
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadTableNameData()
      */
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -241,7 +241,7 @@ class OracleMetadata extends AbstractSource
      *
      * @see \Zend\Db\Metadata\Source\AbstractSource::loadTriggerData()
      */
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -13,6 +13,9 @@ use Zend\Db\Adapter\Adapter;
 
 class PostgresqlMetadata extends AbstractSource
 {
+    /**
+     * @inheritdoc
+     */
     protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
@@ -38,6 +41,9 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
@@ -94,6 +100,9 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
@@ -154,6 +163,9 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
@@ -281,6 +293,9 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -71,7 +71,7 @@ class PostgresqlMetadata extends AbstractSource
             . ' WHERE ' . $p->quoteIdentifierChain(['t', 'table_type'])
             . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['t', 'table_schema'])
                 . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -87,7 +87,7 @@ class PostgresqlMetadata extends AbstractSource
                 'table_type' => $row['table_type'],
                 'view_definition' => $row['view_definition'],
                 'check_option' => $row['check_option'],
-                'is_updatable' => 'YES' == $row['is_updatable'],
+                'is_updatable' => 'YES' === $row['is_updatable'],
             ];
         }
 
@@ -129,7 +129,7 @@ class PostgresqlMetadata extends AbstractSource
             . ' AND ' . $platform->quoteIdentifier('table_name')
             . ' = ' . $platform->quoteTrustedValue($table);
 
-        if ($schema != '__DEFAULT_SCHEMA__') {
+        if ($schema !== '__DEFAULT_SCHEMA__') {
             $sql .= ' AND ' . $platform->quoteIdentifier('table_schema')
                 . ' = ' . $platform->quoteTrustedValue($schema);
         }
@@ -140,7 +140,7 @@ class PostgresqlMetadata extends AbstractSource
             $columns[$row['column_name']] = [
                 'ordinal_position'          => $row['ordinal_position'],
                 'column_default'            => $row['column_default'],
-                'is_nullable'               => 'YES' == $row['is_nullable'],
+                'is_nullable'               => 'YES' === $row['is_nullable'],
                 'data_type'                 => $row['data_type'],
                 'character_maximum_length'  => $row['character_maximum_length'],
                 'character_octet_length'    => $row['character_octet_length'],
@@ -228,7 +228,7 @@ class PostgresqlMetadata extends AbstractSource
              . ' AND ' . $p->quoteIdentifierChain(['t', 'table_type'])
              . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['t', 'table_schema'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -257,12 +257,12 @@ class PostgresqlMetadata extends AbstractSource
                     'constraint_type' => $row['constraint_type'],
                     'table_name'      => $row['table_name'],
                 ];
-                if ('CHECK' == $row['constraint_type']) {
+                if ('CHECK' === $row['constraint_type']) {
                     $constraints[$name]['check_clause'] = $row['check_clause'];
                     continue;
                 }
                 $constraints[$name]['columns'] = [];
-                $isFK = ('FOREIGN KEY' == $row['constraint_type']);
+                $isFK = ('FOREIGN KEY' === $row['constraint_type']);
                 if ($isFK) {
                     $constraints[$name]['referenced_table_schema'] = $row['referenced_table_schema'];
                     $constraints[$name]['referenced_table_name']   = $row['referenced_table_name'];
@@ -323,7 +323,7 @@ class PostgresqlMetadata extends AbstractSource
             . ' FROM ' . $p->quoteIdentifierChain(['information_schema', 'triggers'])
             . ' WHERE ';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= $p->quoteIdentifier('trigger_schema')
                 . ' = ' . $p->quoteTrustedValue($schema);
         } else {

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -87,7 +87,7 @@ class PostgresqlMetadata extends AbstractSource
                 'table_type' => $row['table_type'],
                 'view_definition' => $row['view_definition'],
                 'check_option' => $row['check_option'],
-                'is_updatable' => ('YES' == $row['is_updatable']),
+                'is_updatable' => 'YES' == $row['is_updatable'],
             ];
         }
 
@@ -140,7 +140,7 @@ class PostgresqlMetadata extends AbstractSource
             $columns[$row['column_name']] = [
                 'ordinal_position'          => $row['ordinal_position'],
                 'column_default'            => $row['column_default'],
-                'is_nullable'               => ('YES' == $row['is_nullable']),
+                'is_nullable'               => 'YES' == $row['is_nullable'],
                 'data_type'                 => $row['data_type'],
                 'character_maximum_length'  => $row['character_maximum_length'],
                 'character_octet_length'    => $row['character_octet_length'],

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Adapter;
 
 class PostgresqlMetadata extends AbstractSource
 {
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
             return;
@@ -38,7 +38,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -94,7 +94,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -154,7 +154,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -281,7 +281,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/PostgresqlMetadata.php
+++ b/src/Metadata/Source/PostgresqlMetadata.php
@@ -38,7 +38,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -94,7 +94,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -154,7 +154,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -281,7 +281,7 @@ class PostgresqlMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -37,7 +37,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -93,7 +93,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -157,7 +157,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -285,7 +285,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Adapter;
 
 class SqlServerMetadata extends AbstractSource
 {
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
             return;
@@ -37,7 +37,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -93,7 +93,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -157,7 +157,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -285,7 +285,7 @@ class SqlServerMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -70,7 +70,7 @@ class SqlServerMetadata extends AbstractSource
             . ' WHERE ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
             . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
                 . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -86,7 +86,7 @@ class SqlServerMetadata extends AbstractSource
                 'table_type' => $row['TABLE_TYPE'],
                 'view_definition' => $row['VIEW_DEFINITION'],
                 'check_option' => $row['CHECK_OPTION'],
-                'is_updatable' => 'YES' == $row['IS_UPDATABLE'],
+                'is_updatable' => 'YES' === $row['IS_UPDATABLE'],
             ];
         }
 
@@ -129,7 +129,7 @@ class SqlServerMetadata extends AbstractSource
             . ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_NAME'])
             . '  = ' . $p->quoteTrustedValue($table);
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
                 . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -143,7 +143,7 @@ class SqlServerMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['ORDINAL_POSITION'],
                 'column_default'            => $row['COLUMN_DEFAULT'],
-                'is_nullable'               => 'YES' == $row['IS_NULLABLE'],
+                'is_nullable'               => 'YES' === $row['IS_NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['CHARACTER_MAXIMUM_LENGTH'],
                 'character_octet_length'    => $row['CHARACTER_OCTET_LENGTH'],
@@ -231,7 +231,7 @@ class SqlServerMetadata extends AbstractSource
              . ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_TYPE'])
              . ' IN (\'BASE TABLE\', \'VIEW\')';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= ' AND ' . $p->quoteIdentifierChain(['T', 'TABLE_SCHEMA'])
             . ' = ' . $p->quoteTrustedValue($schema);
         } else {
@@ -261,12 +261,12 @@ class SqlServerMetadata extends AbstractSource
                     'constraint_type' => $row['CONSTRAINT_TYPE'],
                     'table_name'      => $row['TABLE_NAME'],
                 ];
-                if ('CHECK' == $row['CONSTRAINT_TYPE']) {
+                if ('CHECK' === $row['CONSTRAINT_TYPE']) {
                     $constraints[$name]['check_clause'] = $row['CHECK_CLAUSE'];
                     continue;
                 }
                 $constraints[$name]['columns'] = [];
-                $isFK = ('FOREIGN KEY' == $row['CONSTRAINT_TYPE']);
+                $isFK = ('FOREIGN KEY' === $row['CONSTRAINT_TYPE']);
                 if ($isFK) {
                     $constraints[$name]['referenced_table_schema'] = $row['REFERENCED_TABLE_SCHEMA'];
                     $constraints[$name]['referenced_table_name']   = $row['REFERENCED_TABLE_NAME'];
@@ -321,7 +321,7 @@ class SqlServerMetadata extends AbstractSource
             . ' FROM ' . $p->quoteIdentifierChain(['INFORMATION_SCHEMA', 'TRIGGERS'])
             . ' WHERE ';
 
-        if ($schema != self::DEFAULT_SCHEMA) {
+        if ($schema !== self::DEFAULT_SCHEMA) {
             $sql .= $p->quoteIdentifier('TRIGGER_SCHEMA')
                 . ' = ' . $p->quoteTrustedValue($schema);
         } else {

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -86,7 +86,7 @@ class SqlServerMetadata extends AbstractSource
                 'table_type' => $row['TABLE_TYPE'],
                 'view_definition' => $row['VIEW_DEFINITION'],
                 'check_option' => $row['CHECK_OPTION'],
-                'is_updatable' => ('YES' == $row['IS_UPDATABLE']),
+                'is_updatable' => 'YES' == $row['IS_UPDATABLE'],
             ];
         }
 
@@ -143,7 +143,7 @@ class SqlServerMetadata extends AbstractSource
             $columns[$row['COLUMN_NAME']] = [
                 'ordinal_position'          => $row['ORDINAL_POSITION'],
                 'column_default'            => $row['COLUMN_DEFAULT'],
-                'is_nullable'               => ('YES' == $row['IS_NULLABLE']),
+                'is_nullable'               => 'YES' == $row['IS_NULLABLE'],
                 'data_type'                 => $row['DATA_TYPE'],
                 'character_maximum_length'  => $row['CHARACTER_MAXIMUM_LENGTH'],
                 'character_octet_length'    => $row['CHARACTER_OCTET_LENGTH'],

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 

--- a/src/Metadata/Source/SqlServerMetadata.php
+++ b/src/Metadata/Source/SqlServerMetadata.php
@@ -13,6 +13,9 @@ use Zend\Db\Adapter\Adapter;
 
 class SqlServerMetadata extends AbstractSource
 {
+    /**
+     * @inheritdoc
+     */
     protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
@@ -37,6 +40,9 @@ class SqlServerMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
@@ -93,6 +99,9 @@ class SqlServerMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
@@ -157,6 +166,9 @@ class SqlServerMetadata extends AbstractSource
         $this->data['columns'][$schema][$table] = $columns;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
@@ -285,6 +297,9 @@ class SqlServerMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -14,7 +14,7 @@ use Zend\Db\ResultSet\ResultSetInterface;
 
 class SqliteMetadata extends AbstractSource
 {
-    protected function loadSchemaData()
+    protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
             return;
@@ -28,7 +28,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema)
+    protected function loadTableNameData($schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -70,7 +70,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema)
+    protected function loadColumnData($table, $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -103,7 +103,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['sqlite_columns'][$schema][$table] = $results;
     }
 
-    protected function loadConstraintData($table, $schema)
+    protected function loadConstraintData($table, $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -186,7 +186,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema)
+    protected function loadTriggerData($schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;
@@ -278,7 +278,7 @@ class SqliteMetadata extends AbstractSource
         ];
     }
 
-    protected function parseTrigger($sql)
+    protected function parseTrigger($sql) : ?array
     {
         static $re = null;
         if (null === $re) {
@@ -306,7 +306,7 @@ class SqliteMetadata extends AbstractSource
         }
 
         if (! preg_match($re, $sql, $matches)) {
-            return;
+            return null;
         }
         $data = [];
 

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -45,7 +45,7 @@ class SqliteMetadata extends AbstractSource
         $results = $this->adapter->query($sql, Adapter::QUERY_MODE_EXECUTE);
         $tables = [];
         foreach ($results->toArray() as $row) {
-            if ('table' == $row['type']) {
+            if ('table' === $row['type']) {
                 $table = [
                     'table_type' => 'BASE TABLE',
                     'view_definition' => null, // VIEW only
@@ -324,7 +324,7 @@ class SqliteMetadata extends AbstractSource
         }
         if (! empty($data['action_timing'])) {
             $data['action_timing'] = strtoupper($data['action_timing']);
-            if ('I' == $data['action_timing'][0]) {
+            if ('I' === $data['action_timing'][0]) {
                 // normalize the white-space between the two words
                 $data['action_timing'] = 'INSTEAD OF';
             }

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -28,7 +28,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
-    protected function loadTableNameData($schema) : void
+    protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
             return;
@@ -70,7 +70,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
-    protected function loadColumnData($table, $schema) : void
+    protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
             return;
@@ -103,7 +103,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['sqlite_columns'][$schema][$table] = $results;
     }
 
-    protected function loadConstraintData($table, $schema) : void
+    protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
             return;
@@ -186,7 +186,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
-    protected function loadTriggerData($schema) : void
+    protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
             return;
@@ -231,7 +231,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['triggers'][$schema] = $triggers;
     }
 
-    protected function fetchPragma(string $name, string $value = null, string $schema = null)
+    protected function fetchPragma(string $name, ?string $value = null, ?string $schema = null)
     {
         $p = $this->adapter->getPlatform();
 
@@ -253,7 +253,7 @@ class SqliteMetadata extends AbstractSource
         return [];
     }
 
-    protected function parseView($sql)
+    protected function parseView(string $sql)
     {
         static $re = null;
         if (null === $re) {
@@ -278,7 +278,7 @@ class SqliteMetadata extends AbstractSource
         ];
     }
 
-    protected function parseTrigger($sql) : ?array
+    protected function parseTrigger(string $sql) : ?array
     {
         static $re = null;
         if (null === $re) {
@@ -336,7 +336,7 @@ class SqliteMetadata extends AbstractSource
         return $data;
     }
 
-    protected function buildRegularExpression(array $re)
+    protected function buildRegularExpression(array $re) : ?string
     {
         foreach ($re as &$value) {
             if (is_array($value)) {
@@ -350,7 +350,7 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
-    protected function getIdentifierRegularExpression()
+    protected function getIdentifierRegularExpression() : ?string
     {
         static $re = null;
         if (null === $re) {
@@ -365,7 +365,7 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
-    protected function getIdentifierChainRegularExpression()
+    protected function getIdentifierChainRegularExpression() : ?string
     {
         static $re = null;
         if (null === $re) {
@@ -375,7 +375,7 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
-    protected function getIdentifierListRegularExpression()
+    protected function getIdentifierListRegularExpression() : ?string
     {
         static $re = null;
         if (null === $re) {

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -14,6 +14,9 @@ use Zend\Db\ResultSet\ResultSetInterface;
 
 class SqliteMetadata extends AbstractSource
 {
+    /**
+     * @inheritdoc
+     */
     protected function loadSchemaData() : void
     {
         if (isset($this->data['schemas'])) {
@@ -28,6 +31,9 @@ class SqliteMetadata extends AbstractSource
         $this->data['schemas'] = $schemas;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTableNameData(string $schema) : void
     {
         if (isset($this->data['table_names'][$schema])) {
@@ -70,6 +76,9 @@ class SqliteMetadata extends AbstractSource
         $this->data['table_names'][$schema] = $tables;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadColumnData(string $table, string $schema) : void
     {
         if (isset($this->data['columns'][$schema][$table])) {
@@ -103,6 +112,9 @@ class SqliteMetadata extends AbstractSource
         $this->data['sqlite_columns'][$schema][$table] = $results;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadConstraintData(string $table, string $schema) : void
     {
         if (isset($this->data['constraints'][$schema][$table])) {
@@ -186,6 +198,9 @@ class SqliteMetadata extends AbstractSource
         $this->data['constraints'][$schema][$table] = $constraints;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function loadTriggerData(string $schema) : void
     {
         if (isset($this->data['triggers'][$schema])) {
@@ -231,7 +246,15 @@ class SqliteMetadata extends AbstractSource
         $this->data['triggers'][$schema] = $triggers;
     }
 
-    protected function fetchPragma(string $name, ?string $value = null, ?string $schema = null)
+    /**
+     * Fetch pragma
+     *
+     * @param string $name
+     * @param string|null $value
+     * @param string|null $schema
+     * @return array
+     */
+    protected function fetchPragma(string $name, ?string $value = null, ?string $schema = null) : array
     {
         $p = $this->adapter->getPlatform();
 
@@ -253,7 +276,13 @@ class SqliteMetadata extends AbstractSource
         return [];
     }
 
-    protected function parseView(string $sql)
+    /**
+     * Parse view
+     *
+     * @param string $sql
+     * @return array|void
+     */
+    protected function parseView(string $sql) : ?array
     {
         static $re = null;
         if (null === $re) {
@@ -271,13 +300,19 @@ class SqliteMetadata extends AbstractSource
         }
 
         if (! preg_match($re, $sql, $matches)) {
-            return;
+            return null;
         }
         return [
             'view_definition' => $matches['view_definition'],
         ];
     }
 
+    /**
+     * Parse trigger
+     *
+     * @param string $sql
+     * @return array|null
+     */
     protected function parseTrigger(string $sql) : ?array
     {
         static $re = null;
@@ -336,6 +371,10 @@ class SqliteMetadata extends AbstractSource
         return $data;
     }
 
+    /**
+     * @param array $re
+     * @return string|null
+     */
     protected function buildRegularExpression(array $re) : ?string
     {
         foreach ($re as &$value) {
@@ -350,6 +389,9 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
+    /**
+     * @return string|null
+     */
     protected function getIdentifierRegularExpression() : ?string
     {
         static $re = null;
@@ -365,6 +407,9 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
+    /**
+     * @return string|null
+     */
     protected function getIdentifierChainRegularExpression() : ?string
     {
         static $re = null;
@@ -375,6 +420,9 @@ class SqliteMetadata extends AbstractSource
         return $re;
     }
 
+    /**
+     * @return string|null
+     */
     protected function getIdentifierListRegularExpression() : ?string
     {
         static $re = null;

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -231,7 +231,7 @@ class SqliteMetadata extends AbstractSource
         $this->data['triggers'][$schema] = $triggers;
     }
 
-    protected function fetchPragma($name, $value = null, $schema = null)
+    protected function fetchPragma(string $name, string $value = null, string $schema = null)
     {
         $p = $this->adapter->getPlatform();
 

--- a/src/Metadata/Source/SqliteMetadata.php
+++ b/src/Metadata/Source/SqliteMetadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\Metadata\Source;
 


### PR DESCRIPTION
This PR provides changes described in #365 

A few questions came up while refactoring. Some feedback is appreciated:

- Setter returns are inconsistent (e.g. `ColumnObject` and `ConstraintKeyObject`). Since there are fluent setters, possibility is that they are being used. Therefore I recommend to unify and make all setters fluent. If that is okay, I'll provide the changes in this scope.
- Unsure where class constants of `ConstraintKeyObject` and `AbstractSource` are used. Currently the visibility is defined as `public`. If they are not needed elsewhere, `private` or `protected` might be more suitable.
- The `$table` parameter of `loadConstraintData()` and `loadConstraintReferences()` in class `Zend\Db\Metadata\Source\AbstractSource` is unused. Version 3.0 might be a good time to remove it (causing BC). Should I include this change in this scope?
