### PR TITLE
Refactor of `Zend\Db\ResultSet` for 3.0.0

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -100,10 +100,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
 
     public function isBuffered() : bool
     {
-        if ($this->buffer === -1 || is_array($this->buffer)) {
-            return true;
-        }
-        return false;
+        return $this->buffer === -1 || is_array($this->buffer);
     }
 
     public function getDataSource() : ?Iterator

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -54,7 +54,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
-    public function initialize($dataSource)
+    public function initialize($dataSource) : self
     {
         // reset buffering
         if (is_array($this->buffer)) {
@@ -97,7 +97,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * @return self Provides a fluent interface
      * @throws Exception\RuntimeException
      */
-    public function buffer()
+    public function buffer() : self
     {
         if ($this->buffer === -2) {
             throw new Exception\RuntimeException('Buffering must be enabled before iteration is started');
@@ -110,7 +110,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return $this;
     }
 
-    public function isBuffered()
+    public function isBuffered() : bool
     {
         if ($this->buffer === -1 || is_array($this->buffer)) {
             return true;
@@ -123,12 +123,12 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      *
      * @return null|Iterator
      */
-    public function getDataSource()
+    public function getDataSource() : ?Iterator
     {
         return $this->dataSource;
     }
 
-    public function getFieldCount(): int
+    public function getFieldCount() : int
     {
         if (null !== $this->fieldCount) {
             return $this->fieldCount;
@@ -160,7 +160,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      *
      * @return void
      */
-    public function next()
+    public function next() : void
     {
         if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
@@ -174,9 +174,9 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     /**
      * Iterator: retrieve current key
      *
-     * @return mixed
+     * @return int
      */
-    public function key()
+    public function key() : int
     {
         return $this->position;
     }
@@ -210,7 +210,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      *
      * @return bool
      */
-    public function valid()
+    public function valid() : bool
     {
         if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
             return true;
@@ -228,7 +228,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      *
      * @return void
      */
-    public function rewind()
+    public function rewind() : void
     {
         if (! is_array($this->buffer)) {
             if ($this->dataSource instanceof Iterator) {
@@ -245,7 +245,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      *
      * @return int
      */
-    public function count()
+    public function count() : int
     {
         if ($this->count !== null) {
             return $this->count;
@@ -264,7 +264,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * @return array
      * @throws Exception\RuntimeException if any row is not castable to an array
      */
-    public function toArray()
+    public function toArray() : array
     {
         $return = [];
         foreach ($this as $row) {

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -89,12 +89,15 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     {
         if ($this->buffer === -2) {
             throw new Exception\RuntimeException('Buffering must be enabled before iteration is started');
-        } elseif ($this->buffer === null) {
+        }
+
+        if ($this->buffer === null) {
             $this->buffer = [];
             if ($this->dataSource instanceof ResultInterface) {
                 $this->dataSource->rewind();
             }
         }
+
         return $this;
     }
 
@@ -180,12 +183,13 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
             return true;
         }
+
         if ($this->dataSource instanceof Iterator) {
             return $this->dataSource->valid();
-        } else {
-            $key = key($this->dataSource);
-            return ($key !== null);
         }
+
+        $key = key($this->dataSource);
+        return ($key !== null);
     }
 
     public function rewind() : void

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -25,26 +25,18 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * if array, already buffering
      * @var mixed
      */
-    protected $buffer = null;
+    protected $buffer;
 
-    /**
-     * @var null|int
-     */
-    protected $count = null;
+    /** @var null|int */
+    protected $count;
 
-    /**
-     * @var Iterator|IteratorAggregate|ResultInterface
-     */
-    protected $dataSource = null;
+    /** @var Iterator|IteratorAggregate|ResultInterface */
+    protected $dataSource;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $fieldCount = 0;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $position = 0;
 
     /**
@@ -93,10 +85,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return $this;
     }
 
-    /**
-     * @return self Provides a fluent interface
-     * @throws Exception\RuntimeException
-     */
     public function buffer() : self
     {
         if ($this->buffer === -2) {
@@ -118,11 +106,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return false;
     }
 
-    /**
-     * Get the data source used to create the result set
-     *
-     * @return null|Iterator
-     */
     public function getDataSource() : ?Iterator
     {
         return $this->dataSource;
@@ -155,11 +138,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return $this->fieldCount;
     }
 
-    /**
-     * Iterator: move pointer to next item
-     *
-     * @return void
-     */
     public function next() : void
     {
         if ($this->buffer === null) {
@@ -171,11 +149,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         $this->position++;
     }
 
-    /**
-     * Iterator: retrieve current key
-     *
-     * @return int
-     */
     public function key() : int
     {
         return $this->position;
@@ -205,11 +178,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return is_array($data) ? $data : null;
     }
 
-    /**
-     * Iterator: is pointer valid?
-     *
-     * @return bool
-     */
     public function valid() : bool
     {
         if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
@@ -223,11 +191,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         }
     }
 
-    /**
-     * Iterator: rewind
-     *
-     * @return void
-     */
     public function rewind() : void
     {
         if (! is_array($this->buffer)) {
@@ -240,11 +203,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         $this->position = 0;
     }
 
-    /**
-     * Countable: return count of rows
-     *
-     * @return int
-     */
     public function count() : int
     {
         if ($this->count !== null) {

--- a/src/ResultSet/Exception/ExceptionInterface.php
+++ b/src/ResultSet/Exception/ExceptionInterface.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet\Exception;
 

--- a/src/ResultSet/Exception/InvalidArgumentException.php
+++ b/src/ResultSet/Exception/InvalidArgumentException.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet\Exception;
 

--- a/src/ResultSet/Exception/RuntimeException.php
+++ b/src/ResultSet/Exception/RuntimeException.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet\Exception;
 

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet;
 

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -16,23 +16,13 @@ use Zend\Hydrator\HydratorInterface;
 
 class HydratingResultSet extends AbstractResultSet
 {
-    /**
-     * @var HydratorInterface
-     */
-    protected $hydrator = null;
+    /** @var HydratorInterface */
+    protected $hydrator;
 
-    /**
-     * @var null|object
-     */
-    protected $objectPrototype = null;
+    /** @var null|object */
+    protected $objectPrototype;
 
-    /**
-     * Constructor
-     *
-     * @param  null|HydratorInterface $hydrator
-     * @param  null|object $objectPrototype
-     */
-    public function __construct(HydratorInterface $hydrator = null, $objectPrototype = null)
+    public function __construct(?HydratorInterface $hydrator = null, ?object $objectPrototype = null)
     {
         $defaultHydratorClass = class_exists(ArraySerializableHydrator::class)
             ? ArraySerializableHydrator::class
@@ -41,13 +31,6 @@ class HydratingResultSet extends AbstractResultSet
         $this->setObjectPrototype(($objectPrototype) ?: new ArrayObject);
     }
 
-    /**
-     * Set the row object prototype
-     *
-     * @param  object $objectPrototype
-     * @return self Provides a fluent interface
-     * @throws Exception\InvalidArgumentException
-     */
     public function setObjectPrototype($objectPrototype) : self
     {
         if (! is_object($objectPrototype)) {
@@ -59,33 +42,17 @@ class HydratingResultSet extends AbstractResultSet
         return $this;
     }
 
-    /**
-     * Get the row object prototype
-     *
-     * @return object
-     */
     public function getObjectPrototype() : object
     {
         return $this->objectPrototype;
     }
 
-    /**
-     * Set the hydrator to use for each row object
-     *
-     * @param HydratorInterface $hydrator
-     * @return self Provides a fluent interface
-     */
     public function setHydrator(HydratorInterface $hydrator) : self
     {
         $this->hydrator = $hydrator;
         return $this;
     }
 
-    /**
-     * Get the hydrator to use for each row object
-     *
-     * @return HydratorInterface
-     */
     public function getHydrator() : HydratorInterface
     {
         return $this->hydrator;
@@ -113,12 +80,6 @@ class HydratingResultSet extends AbstractResultSet
         return $object;
     }
 
-    /**
-     * Cast result set to array of arrays
-     *
-     * @return array
-     * @throws Exception\RuntimeException if any row is not castable to an array
-     */
     public function toArray() : array
     {
         $return = [];

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -28,7 +28,7 @@ class HydratingResultSet extends AbstractResultSet
             ? ArraySerializableHydrator::class
             : ArraySerializable::class;
         $this->setHydrator($hydrator ?: new $defaultHydratorClass());
-        $this->setObjectPrototype(($objectPrototype) ?: new ArrayObject);
+        $this->setObjectPrototype($objectPrototype ?: new ArrayObject);
     }
 
     public function setObjectPrototype(object $objectPrototype) : self

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -31,13 +31,8 @@ class HydratingResultSet extends AbstractResultSet
         $this->setObjectPrototype(($objectPrototype) ?: new ArrayObject);
     }
 
-    public function setObjectPrototype($objectPrototype) : self
+    public function setObjectPrototype(object $objectPrototype) : self
     {
-        if (! is_object($objectPrototype)) {
-            throw new Exception\InvalidArgumentException(
-                'An object must be set as the object prototype, a ' . gettype($objectPrototype) . ' was provided.'
-            );
-        }
         $this->objectPrototype = $objectPrototype;
         return $this;
     }

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -48,7 +48,7 @@ class HydratingResultSet extends AbstractResultSet
      * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
-    public function setObjectPrototype($objectPrototype)
+    public function setObjectPrototype($objectPrototype) : self
     {
         if (! is_object($objectPrototype)) {
             throw new Exception\InvalidArgumentException(
@@ -64,7 +64,7 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @return object
      */
-    public function getObjectPrototype()
+    public function getObjectPrototype() : object
     {
         return $this->objectPrototype;
     }
@@ -75,7 +75,7 @@ class HydratingResultSet extends AbstractResultSet
      * @param HydratorInterface $hydrator
      * @return self Provides a fluent interface
      */
-    public function setHydrator(HydratorInterface $hydrator)
+    public function setHydrator(HydratorInterface $hydrator) : self
     {
         $this->hydrator = $hydrator;
         return $this;
@@ -86,7 +86,7 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @return HydratorInterface
      */
-    public function getHydrator()
+    public function getHydrator() : HydratorInterface
     {
         return $this->hydrator;
     }
@@ -94,7 +94,7 @@ class HydratingResultSet extends AbstractResultSet
     /**
      * Iterator: get current item
      *
-     * @return object
+     * @return null|array|bool
      */
     public function current()
     {
@@ -119,7 +119,7 @@ class HydratingResultSet extends AbstractResultSet
      * @return array
      * @throws Exception\RuntimeException if any row is not castable to an array
      */
-    public function toArray()
+    public function toArray() : array
     {
         $return = [];
         foreach ($this as $row) {

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet;
 

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -39,7 +39,7 @@ class ResultSet extends AbstractResultSet
             $this->returnType = self::TYPE_ARRAYOBJECT;
         }
         if ($this->returnType === self::TYPE_ARRAYOBJECT) {
-            $this->setArrayObjectPrototype(($arrayObjectPrototype) ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
+            $this->setArrayObjectPrototype($arrayObjectPrototype ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
         }
     }
 

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -13,8 +13,8 @@ use ArrayObject;
 
 class ResultSet extends AbstractResultSet
 {
-    const TYPE_ARRAYOBJECT = 'arrayobject';
-    const TYPE_ARRAY  = 'array';
+    public const TYPE_ARRAYOBJECT = 'arrayobject';
+    public const TYPE_ARRAY  = 'array';
 
     protected $allowedReturnTypes = [
         self::TYPE_ARRAYOBJECT,

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -16,35 +16,22 @@ class ResultSet extends AbstractResultSet
     const TYPE_ARRAYOBJECT = 'arrayobject';
     const TYPE_ARRAY  = 'array';
 
-    /**
-     * Allowed return types
-     *
-     * @var array
-     */
     protected $allowedReturnTypes = [
         self::TYPE_ARRAYOBJECT,
         self::TYPE_ARRAY,
     ];
 
-    /**
-     * @var ArrayObject
-     */
-    protected $arrayObjectPrototype = null;
+    /** @var ArrayObject */
+    protected $arrayObjectPrototype;
 
     /**
      * Return type to use when returning an object from the set
      *
-     * @var ResultSet::TYPE_ARRAYOBJECT|ResultSet::TYPE_ARRAY
+     * @var string One of the above declared TYPE constants
      */
     protected $returnType = self::TYPE_ARRAYOBJECT;
 
-    /**
-     * Constructor
-     *
-     * @param string           $returnType
-     * @param null|ArrayObject $arrayObjectPrototype
-     */
-    public function __construct($returnType = self::TYPE_ARRAYOBJECT, $arrayObjectPrototype = null)
+    public function __construct(string $returnType = self::TYPE_ARRAYOBJECT, ?ArrayObject $arrayObjectPrototype = null)
     {
         if (in_array($returnType, [self::TYPE_ARRAY, self::TYPE_ARRAYOBJECT])) {
             $this->returnType = $returnType;
@@ -56,13 +43,6 @@ class ResultSet extends AbstractResultSet
         }
     }
 
-    /**
-     * Set the row object prototype
-     *
-     * @param  ArrayObject $arrayObjectPrototype
-     * @return self Provides a fluent interface
-     * @throws Exception\InvalidArgumentException
-     */
     public function setArrayObjectPrototype($arrayObjectPrototype) : self
     {
         if (! is_object($arrayObjectPrototype)
@@ -79,28 +59,18 @@ class ResultSet extends AbstractResultSet
         return $this;
     }
 
-    /**
-     * Get the row object prototype
-     *
-     * @return ArrayObject
-     */
     public function getArrayObjectPrototype() : ArrayObject
     {
         return $this->arrayObjectPrototype;
     }
 
-    /**
-     * Get the return type to use when returning objects from the set
-     *
-     * @return string
-     */
     public function getReturnType() : string
     {
         return $this->returnType;
     }
 
     /**
-     * @return array|\ArrayObject|null
+     * @return array|ArrayObject|null
      */
     public function current()
     {

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -63,7 +63,7 @@ class ResultSet extends AbstractResultSet
      * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
-    public function setArrayObjectPrototype($arrayObjectPrototype)
+    public function setArrayObjectPrototype($arrayObjectPrototype) : self
     {
         if (! is_object($arrayObjectPrototype)
             || (
@@ -84,7 +84,7 @@ class ResultSet extends AbstractResultSet
      *
      * @return ArrayObject
      */
-    public function getArrayObjectPrototype()
+    public function getArrayObjectPrototype() : ArrayObject
     {
         return $this->arrayObjectPrototype;
     }
@@ -94,7 +94,7 @@ class ResultSet extends AbstractResultSet
      *
      * @return string
      */
-    public function getReturnType()
+    public function getReturnType() : string
     {
         return $this->returnType;
     }

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -43,13 +43,10 @@ class ResultSet extends AbstractResultSet
         }
     }
 
-    public function setArrayObjectPrototype($arrayObjectPrototype) : self
+    public function setArrayObjectPrototype(object $arrayObjectPrototype) : self
     {
-        if (! is_object($arrayObjectPrototype)
-            || (
-                ! $arrayObjectPrototype instanceof ArrayObject
-                && ! method_exists($arrayObjectPrototype, 'exchangeArray')
-            )
+        if (! $arrayObjectPrototype instanceof ArrayObject
+            && ! method_exists($arrayObjectPrototype, 'exchangeArray')
         ) {
             throw new Exception\InvalidArgumentException(
                 'Object must be of type ArrayObject, or at least implement exchangeArray'

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-db for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-db/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Db\ResultSet;
 


### PR DESCRIPTION
This PR provides changes described in #364 

I have two questions from refactoring.

1. Return type hints for implementations of `\Iterator::current()` is incomplete due to inconsistent usage. Right now, type hints are only documented in method comment. Either leave it or a change is required to match return types.

- `Iterator::current()` [documents](https://php.net/manual/en/iterator.current.php) a mixed (any) type 
- `AbstractResultSet::current()` documents `array|null`
- `ResultSet::current()` documents `array|ArrayObject|null`
- `HydratingResultSet::current()` documents `null|array|bool`

2. `ExtractionInterface::extract()` expects parameter be of type object. From my understanding `HydratingResultSet::toArray()` could give provide any of `null|array|bool`. Not sure if I misunderstand it or if that needs some attention.