### PR TITLE
Adding schema for Postgres

### DIFF
--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -12,6 +12,7 @@ namespace Zend\Db\TableGateway\Feature;
 use Zend\Db\Sql\Insert;
 use Zend\Db\Adapter\Driver\ResultInterface;
 use Zend\Db\Adapter\Driver\StatementInterface;
+use Zend\Db\Sql\TableIdentifier;
 
 class SequenceFeature extends AbstractFeature
 {
@@ -24,6 +25,11 @@ class SequenceFeature extends AbstractFeature
      * @var string
      */
     protected $sequenceName;
+
+    /**
+     * @var string
+     */
+    protected $schemaName = NULL;
 
     /**
      * @var int
@@ -39,6 +45,11 @@ class SequenceFeature extends AbstractFeature
     {
         $this->primaryKeyField = $primaryKeyField;
         $this->sequenceName    = $sequenceName;
+
+        if($sequenceName instanceof TableIdentifier) {
+            $this->sequenceName = $sequenceName->getTable();
+            $this->schemaName = $sequenceName->getSchema();
+        }
     }
 
     /**
@@ -90,6 +101,9 @@ class SequenceFeature extends AbstractFeature
                 break;
             case 'PostgreSQL':
                 $sql = 'SELECT NEXTVAL(\'"' . $this->sequenceName . '"\')';
+                if($this->schemaName !== NULL) {
+                    $sql = 'SELECT NEXTVAL(\'"' . $this->schemaName . '"."' . $this->sequenceName . '"\')';
+                }
                 break;
             default:
                 return;
@@ -118,6 +132,9 @@ class SequenceFeature extends AbstractFeature
                 break;
             case 'PostgreSQL':
                 $sql = 'SELECT CURRVAL(\'' . $this->sequenceName . '\')';
+                if($this->schemaName !== NULL) {
+                    $sql = 'SELECT CURRVAL(\'"' . $this->schemaName . '"."' . $this->sequenceName . '"\')';
+                }
                 break;
             default:
                 return;


### PR DESCRIPTION
Postgres sequence can use other schema than public. In this case NEXTVAL and CURRVAL should include Schema name like NEXTVAL("schema"."sequence_name"). In standard approach result of SequenceFeature class was NEXTVAL("schema.sequence_name") which is inproper behavior. I added checking, if the $sequenceName is instance of TableIdentifier. In this case NEXTVAL and CURRVALL is modified.

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
