### PR TITLE
removed `getHelpers`

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -234,26 +234,6 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
         return $statement;
     }
 
-    public function getHelpers()
-    {
-        $functions = [];
-        $platform = $this->platform;
-        foreach (func_get_args() as $arg) {
-            switch ($arg) {
-                case self::FUNCTION_QUOTE_IDENTIFIER:
-                    $functions[] = function ($value) use ($platform) {
-                        return $platform->quoteIdentifier($value);
-                    };
-                    break;
-                case self::FUNCTION_QUOTE_VALUE:
-                    $functions[] = function ($value) use ($platform) {
-                        return $platform->quoteValue($value);
-                    };
-                    break;
-            }
-        }
-    }
-
     /**
      * @param $name
      * @throws Exception\InvalidArgumentException


### PR DESCRIPTION

method remained unused for 7 years and is bugged, see https://github.com/zendframework/zend-db/issues/379
 for details