### PR TITLE
pdo_mysql fix for too strongly casting integer parameters

### DIFF
--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -269,8 +269,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         foreach ($parameters as $name => &$value) {
             if (is_bool($value)) {
                 $type = \PDO::PARAM_BOOL;
-            } elseif (is_int($value)) {
-                $type = \PDO::PARAM_INT;
             } else {
                 $type = \PDO::PARAM_STR;
             }

--- a/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
+++ b/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
@@ -16,7 +16,8 @@ class QueryTest extends TestCase
         return [
             ['SELECT * FROM test WHERE id = ?', [1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
             ['SELECT * FROM test WHERE id = :id', [':id' => 1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
-            ['SELECT * FROM test WHERE id = :id', ['id' => 1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']]
+            ['SELECT * FROM test WHERE id = :id', ['id' => 1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
+            ['SELECT * FROM test WHERE name = ?', [123], ['id' => 4, 'name' => '123', 'value' => 'bar']],
         ];
     }
 

--- a/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
+++ b/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
@@ -17,7 +17,7 @@ class QueryTest extends TestCase
             ['SELECT * FROM test WHERE id = ?', [1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
             ['SELECT * FROM test WHERE id = :id', [':id' => 1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
             ['SELECT * FROM test WHERE id = :id', ['id' => 1], ['id' => 1, 'name' => 'foo', 'value' => 'bar']],
-            ['SELECT * FROM test WHERE name = ?', [123], ['id' => 4, 'name' => '123', 'value' => 'bar']],
+            ['SELECT * FROM test WHERE name = ?', [123], ['id' => '4', 'name' => '123', 'value' => 'bar']],
         ];
     }
 

--- a/test/integration/TestFixtures/mysql.sql
+++ b/test/integration/TestFixtures/mysql.sql
@@ -9,7 +9,7 @@ INSERT INTO test (name, value) VALUES
 ('foo', 'bar'),
 ('bar', 'baz'),
 ('123a', 'bar'),
-('123', 'baz');
+('123', 'bar');
 
 CREATE TABLE IF NOT EXISTS test_charset (
     id INT NOT NULL AUTO_INCREMENT,

--- a/test/integration/TestFixtures/mysql.sql
+++ b/test/integration/TestFixtures/mysql.sql
@@ -7,7 +7,9 @@ CREATE TABLE IF NOT EXISTS test (
 
 INSERT INTO test (name, value) VALUES
 ('foo', 'bar'),
-('bar', 'baz');
+('bar', 'baz'),
+('123a', 'bar'),
+('123', 'baz');
 
 CREATE TABLE IF NOT EXISTS test_charset (
     id INT NOT NULL AUTO_INCREMENT,

--- a/test/unit/Adapter/Driver/Pdo/StatementIntegrationTest.php
+++ b/test/unit/Adapter/Driver/Pdo/StatementIntegrationTest.php
@@ -71,4 +71,14 @@ class StatementIntegrationTest extends TestCase
         );
         $this->statement->execute(['foo' => 'bar']);
     }
+
+    public function testStatementExecuteWillUsePdoStrForIntWhenBinding()
+    {
+        $this->pdoStatementMock->expects($this->any())->method('bindParam')->with(
+            $this->equalTo(':foo'),
+            $this->equalTo(123),
+            $this->equalTo(\PDO::PARAM_STR)
+        );
+        $this->statement->execute(['foo' => 123]);
+    }
 }


### PR DESCRIPTION
Related issue: #383 
pdo_mysql adapter casts integer values as PDO::PARAM_INT causing unexpected results
