### PR TITLE
Update `join()` documentation: First parameter can be instance of `TableIdentifier`

### DIFF
--- a/docs/book/sql.md
+++ b/docs/book/sql.md
@@ -128,7 +128,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     public function __construct(string|array|TableIdentifier $table = null);
     public function from(string|array|TableIdentifier $table) : self;
     public function columns(array $columns, bool $prefixColumnsWithTable = true) : self;
-    public function join(string|array $name, string $on, string|array $columns = self::SQL_STAR, string $type = self::JOIN_INNER) : self;
+    public function join(string|array|TableIdentifier $name, string $on, string|array $columns = self::SQL_STAR, string $type = self::JOIN_INNER) : self;
     public function where(Where|callable|string|array|PredicateInterface $predicate, string $combination = Predicate\PredicateSet::OP_AND) : self;
     public function group(string|array $group);
     public function having(Having|callable|string|array $predicate, string $combination = Predicate\PredicateSet::OP_AND) : self;


### PR DESCRIPTION
Update `join()` documentation: First parameter can be instance of `TableIdentifier`.
See https://github.com/zendframework/zend-db/blob/master/src/Sql/Select.php#L265 (**updated**)

Provide a narrative description of what you are trying to accomplish:

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
