### PR TITLE
update return type test logic

### DIFF
--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -46,7 +46,7 @@ class ResultSet extends AbstractResultSet
      */
     public function __construct($returnType = self::TYPE_ARRAYOBJECT, $arrayObjectPrototype = null)
     {
-        if (in_array($returnType, [self::TYPE_ARRAY, self::TYPE_ARRAYOBJECT])) {
+        if (in_array($returnType, $this->allowedReturnTypes, true)) {
             $this->returnType = $returnType;
         } else {
             $this->returnType = self::TYPE_ARRAYOBJECT;


### PR DESCRIPTION
- use internal property `$allowedReturnTypes` (maybe making it a static property or a class constant would be advisable)
- use strict `in_array` test as for instance this expression `in_array(0, ['a', 'b'])` evaluates to true
