### PR TITLE
fix Trying to access array offset on value of type null

### DIFF
--- a/src/RowGateway/AbstractRowGateway.php
+++ b/src/RowGateway/AbstractRowGateway.php
@@ -204,7 +204,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         $where = [];
         // primary key is always an array even if its a single column
         foreach ($this->primaryKeyColumn as $pkColumn) {
-            $where[$pkColumn] = $this->primaryKeyData[$pkColumn];
+            $where[$pkColumn] = ($this->primaryKeyData ? $this->primaryKeyData[$pkColumn] : null);
         }
 
         // @todo determine if we need to do a select to ensure 1 row will be affected

--- a/src/TableGateway/AbstractTableGateway.php
+++ b/src/TableGateway/AbstractTableGateway.php
@@ -216,7 +216,8 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected function executeSelect(Select $select)
     {
         $selectState = $select->getRawState();
-        if ($selectState['table'] != $this->table
+        if (isset($selectState['table'])
+            && $selectState['table'] != $this->table
             && (is_array($selectState['table'])
                 && end($selectState['table']) != $this->table)
         ) {
@@ -225,7 +226,8 @@ abstract class AbstractTableGateway implements TableGatewayInterface
             );
         }
 
-        if ($selectState['columns'] == [Select::SQL_STAR]
+        if (isset($selectState['columns'])
+            && $selectState['columns'] == [Select::SQL_STAR]
             && $this->columns !== []) {
             $select->columns($this->columns);
         }


### PR DESCRIPTION
With 7.4.0RC3

```
There were 2 errors:

1) ZendTest\Db\RowGateway\AbstractRowGatewayTest::testDelete
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-db-2.10.0-2.fc29.remi.x86_64/usr/share/php/Zend/Db/RowGateway/AbstractRowGateway.php:207
/dev/shm/BUILD/zend-db-77022f06f6ffd384fa86d22ab8d8bbdb925a1e8e/test/unit/RowGateway/AbstractRowGatewayTest.php:257

2) ZendTest\Db\TableGateway\AbstractTableGatewayTest::testSelectWithNoWhere
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-db-2.10.0-2.fc29.remi.x86_64/usr/share/php/Zend/Db/TableGateway/AbstractTableGateway.php:219
/dev/shm/BUILDROOT/php-zendframework-zend-db-2.10.0-2.fc29.remi.x86_64/usr/share/php/Zend/Db/TableGateway/AbstractTableGateway.php:208
/dev/shm/BUILDROOT/php-zendframework-zend-db-2.10.0-2.fc29.remi.x86_64/usr/share/php/Zend/Db/TableGateway/AbstractTableGateway.php:196
/dev/shm/BUILD/zend-db-77022f06f6ffd384fa86d22ab8d8bbdb925a1e8e/test/unit/TableGateway/AbstractTableGatewayTest.php:163

```
