### PR TITLE
add support for BLOB data in OCI8 driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.10.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.10.0 - 2019-02-25
 
 ### Added

--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -289,10 +289,17 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
                         $type = SQLT_BIN;
                         break;
                     case ParameterContainer::TYPE_LOB:
+                    case ParameterContainer::TYPE_CLOB:
                         $type = OCI_B_CLOB;
                         $clob = oci_new_descriptor($this->driver->getConnection()->getResource(), OCI_DTYPE_LOB);
                         $clob->writetemporary($value, OCI_TEMP_CLOB);
                         $value = $clob;
+                        break;
+                    case ParameterContainer::TYPE_BLOB:
+                        $type = OCI_B_BLOB;
+                        $blob = oci_new_descriptor($this->driver->getConnection()->getResource(), OCI_DTYPE_LOB);
+                        $blob->writetemporary($value, OCI_TEMP_BLOB);
+                        $value = $blob;
                         break;
                     case ParameterContainer::TYPE_STRING:
                     default:

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -22,6 +22,8 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     const TYPE_BINARY  = 'binary';
     const TYPE_STRING  = 'string';
     const TYPE_LOB     = 'lob';
+    const TYPE_BLOB = 'blob';
+    const TYPE_CLOB = 'clob';
 
     /**
      * Data


### PR DESCRIPTION
- add 2 new data types in ParameterContainer class in order to manage differently BLOB from CLOB,
- for oci8 driver: add a new case statement in bindParametersFromContainer() method to save data binded as BLOB