### PR TITLE
Hotfix #376: Accessing constraint metadata within the Oracle adapter

### DIFF
--- a/src/Metadata/Source/OracleMetadata.php
+++ b/src/Metadata/Source/OracleMetadata.php
@@ -172,6 +172,8 @@ class OracleMetadata extends AbstractSource
             }
         }
 
+        $this->data['constraints'][$schema][$table] = $constraints;
+
         return $this;
     }
 


### PR DESCRIPTION
Fixes #376 

The `OracleMetadata::loadConstraintData` method simply does not work:
```php
$metadata = \Zend\Db\Metadata\Source\Factory::createSourceFromAdapter($adapter);
$constraints = $metadata->getConstraints($table, $schema); // always an empty array
```

The existing test couldn't catch it because there is no real table involved:
https://github.com/zendframework/zend-db/blob/4c68f2c33beb76d63a59c5bd5e6c96c9763966d7/test/unit/Metadata/Source/OracleMetadataTest.php#L48-L49